### PR TITLE
Fix variable name typo in Ingest_Incremental.sql

### DIFF
--- a/src/single_batch/SQL/Ingest_Incremental.sql
+++ b/src/single_batch/SQL/Ingest_Incremental.sql
@@ -1,10 +1,9 @@
 -- Databricks notebook source
 CREATE OR REPLACE TABLE IDENTIFIER(:catalog || '.' || :wh_db || '_' || :scale_factor || '.' || :tbl) (
   ${raw_schema},
-  batchid INT COMMENT 'Batch ID when this record was inserted'
-  ${constraints}
+  batchid INT COMMENT 'Batch ID when this record was inserted'${constraints}
 )
-TBLPROPERTIES (${tblprops});
+TBLPROPERTIES (${tbl_props});
 
 -- COMMAND ----------
 


### PR DESCRIPTION
## Summary
Fixed a typo in the TBLPROPERTIES clause where 'tblprops' should be 'tbl_props'.

## Changes
- **File**: 
- **Fix**: Changed  to  on line 6
- **Issue**: Missing underscore in variable name was causing inconsistent template variable naming

## Impact
- Ensures consistent variable naming throughout SQL templates
- Resolves potential template substitution errors when the correct variable name is used elsewhere
- Maintains compatibility with existing template processing logic

## Testing
- [x] Verified variable name consistency across codebase
- [x] Confirmed SQL syntax remains valid after fix

This is a small but important fix for template variable consistency.