### PR TITLE
augmented_incremental: SF=20k bug fixes (RPC limit, cashtx backfill, cleanup gating)

### DIFF
--- a/src/incremental_batches/augmented_incremental/historical/FactCashBalancesHistorical.sql
+++ b/src/incremental_batches/augmented_incremental/historical/FactCashBalancesHistorical.sql
@@ -27,8 +27,11 @@ TBLPROPERTIES (
   'delta.autoOptimize.autoCompact' = 'true',
   'delta.autoOptimize.optimizeWrite' = 'true'
 );
+-- Spark gen omits cdc_flag from the cashtransaction Delta (it's always
+-- 'I' for CashTransaction); stage_files/CashTransaction.py synthesizes
+-- it at file-write time. Mirror that here.
 INSERT OVERWRITE cashtransactionhistorical
-SELECT cdc_flag, cdc_dsn, accountid, ct_dts, ct_amt, ct_name,
+SELECT 'I' AS cdc_flag, cdc_dsn, accountid, ct_dts, ct_amt, ct_name,
        to_date(ct_dts) AS event_dt
 FROM IDENTIFIER(:catalog || '.tpcdi_raw_data.cashtransaction' || :scale_factor)
 WHERE stg_target = 'tables';

--- a/src/tools/tpcdi_gen/customer.py
+++ b/src/tools/tpcdi_gen/customer.py
@@ -398,40 +398,49 @@ def generate_customermgmt(spark: SparkSession, cfg, dicts: dict, dbutils, views_
         f"(INACT={n_inact} CLOSE={n_close} UPDCUST={n_updcust} "
         f"UPDACCT={n_updacct} ADDACCT={n_addacct})", "DEBUG")
 
-    # Convert to Spark via Arrow-backed pandas path (vastly faster than createDataFrame on a list of Python tuples). Single unified DF means a single join against all_df instead of five chained joins.
-    log("[CustomerMgmt] building pandas DataFrame from numpy buffers", "DEBUG")
-    _sched_pdf = _pd.DataFrame({
+    # Persist the schedule numpy buffers directly to Parquet on the volume
+    # via pyarrow on the driver, then re-read as a Spark DataFrame.
+    #
+    # We deliberately avoid `spark.createDataFrame(pandas_df)` here because
+    # on Spark Connect serverless that path embeds the entire pandas
+    # payload in the LogicalPlan as a LocalRelation literal — the subsequent
+    # write task's serialized plan then carries the full data set. At
+    # SF=20000 the schedule is ~70M rows × 32 B ≈ 2.2 GB, blowing past
+    # spark.rpc.message.maxSize (256 MB, NOT settable on serverless) with
+    # `Serialized task ... was 494762139 bytes`. Coalesce / repartition
+    # can't fix it because the data is in the plan, not in input
+    # partitions. Writing the parquet directly via pyarrow → spark.read
+    # makes the data flow through the volume's FUSE mount instead of the
+    # Spark Connect control plane.
+    import pyarrow as _pa
+    import pyarrow.parquet as _pq
+    log("[CustomerMgmt] building Arrow Table from numpy buffers", "DEBUG")
+    _sched_action_str = _np.array(["INACT", "CLOSEACCT", "UPDCUST",
+                                    "UPDACCT", "ADDACCT"])[sched_action]
+    _sched_table = _pa.table({
         "_sched_update": sched_update,
-        "_sched_action_code": sched_action.astype(_np.int32),
+        "_sched_action": _sched_action_str,
         "_sched_pos": sched_pos,
         "_sched_id": sched_id,
     })
-    del sched_update, sched_action, sched_pos, sched_id
+    del sched_update, sched_action, sched_pos, sched_id, _sched_action_str
 
-    log("[CustomerMgmt] Arrow-converting pandas → Spark DataFrame", "DEBUG")
-    # Arrow is on by default on serverless; conf is on the user-settable allowlist for classic. safe_conf_set is a no-op if the runtime rejects it.
-    from .utils import safe_conf_set
-    safe_conf_set(spark, "spark.sql.execution.arrow.pyspark.enabled", "true")
-    schedule_df = spark.createDataFrame(_sched_pdf)
-    del _sched_pdf
-
-    # Collapse Arrow batch partitions into a small number of writers. With Arrow enabled, createDataFrame(pandas) produces one partition per arrow.maxRecordsPerBatch (default 10K rows) — ~6944 partitions at SF=20000. Without this, Photon's writer auto-rotates files at ~217K rows (per-file byte budget), producing 320+ tiny files written serially by one task — ~7 min wall-clock for a 584 MB output. coalesce (not repartition) because we only need to reduce fan-out; a shuffle would be wasted work. Target ~30 MB per partition: total schedule rows scale ~17K/SF (across all action types × 32 B/row). At SF=20000 with the previous `cfg.sf // 2500` formula we got 8 partitions × ~280 MB each → blew past spark.rpc.message.maxSize (256 MB) when Spark Connect serialized the bound Arrow relation. cfg.sf // 250 keeps each task under ~30 MB at SF=20000 and still 8 at SF≤2000.
-    _sched_target_parts = max(8, cfg.sf // 250)
-    schedule_df = schedule_df.coalesce(_sched_target_parts)
-
-    # Map action_code → ActionType string so the join key matches all_df.
-    schedule_df = schedule_df.withColumn("_sched_action",
-        F.when(F.col("_sched_action_code") == ACT_INACT,   F.lit("INACT"))
-         .when(F.col("_sched_action_code") == ACT_CLOSE,   F.lit("CLOSEACCT"))
-         .when(F.col("_sched_action_code") == ACT_UPDCUST, F.lit("UPDCUST"))
-         .when(F.col("_sched_action_code") == ACT_UPDACCT, F.lit("UPDACCT"))
-         .otherwise(F.lit("ADDACCT"))
-    ).drop("_sched_action_code")
-
-    log("[CustomerMgmt] staging schedule DF to Parquet", "DEBUG")
-    schedule_df, _sched_cleanup = disk_cache(
-        schedule_df, spark, "CustomerMgmt schedules",
-        volume_path=cfg.volume_path, dbutils=dbutils)
+    _STAGING_COUNTER_LOCAL = 99  # outside the disk_cache counter range
+    _sched_path = (f"{cfg.volume_path}/_staging/"
+                   f"{_STAGING_COUNTER_LOCAL:03d}_customermgmt_schedules.parquet")
+    _sched_path_fuse = _sched_path[5:] if _sched_path.startswith("dbfs:") else _sched_path
+    log(f"[CustomerMgmt] writing schedule Parquet directly to {_sched_path_fuse}", "DEBUG")
+    import os as _os
+    _os.makedirs(_os.path.dirname(_sched_path_fuse), exist_ok=True)
+    # Cap each row group / output file size so the read-back fans out
+    # across reasonable partition count. ~5M rows per file at SF=20000
+    # gives ~14 files = 14 input splits.
+    _pq.write_table(_sched_table, _sched_path_fuse,
+                    row_group_size=5_000_000)
+    del _sched_table
+    schedule_df = spark.read.parquet(_sched_path)
+    _sched_cleanup = {"kind": "parquet", "path": _sched_path,
+                      "dbutils": dbutils, "label": "CustomerMgmt schedules"}
     log("[CustomerMgmt] schedule staged", "DEBUG")
 
     # === Assign C_ID ===

--- a/src/tools/tpcdi_gen/customer.py
+++ b/src/tools/tpcdi_gen/customer.py
@@ -415,8 +415,8 @@ def generate_customermgmt(spark: SparkSession, cfg, dicts: dict, dbutils, views_
     schedule_df = spark.createDataFrame(_sched_pdf)
     del _sched_pdf
 
-    # Collapse Arrow batch partitions into a small number of writers. With Arrow enabled, createDataFrame(pandas) produces one partition per arrow.maxRecordsPerBatch (default 10K rows) — ~6944 partitions at SF=20000. Without this, Photon's writer auto-rotates files at ~217K rows (per-file byte budget), producing 320+ tiny files written serially by one task — ~7 min wall-clock for a 584 MB output. coalesce (not repartition) because we only need to reduce fan-out; a shuffle would be wasted work.
-    _sched_target_parts = max(8, cfg.sf // 2500)
+    # Collapse Arrow batch partitions into a small number of writers. With Arrow enabled, createDataFrame(pandas) produces one partition per arrow.maxRecordsPerBatch (default 10K rows) — ~6944 partitions at SF=20000. Without this, Photon's writer auto-rotates files at ~217K rows (per-file byte budget), producing 320+ tiny files written serially by one task — ~7 min wall-clock for a 584 MB output. coalesce (not repartition) because we only need to reduce fan-out; a shuffle would be wasted work. Target ~30 MB per partition: total schedule rows scale ~17K/SF (across all action types × 32 B/row). At SF=20000 with the previous `cfg.sf // 2500` formula we got 8 partitions × ~280 MB each → blew past spark.rpc.message.maxSize (256 MB) when Spark Connect serialized the bound Arrow relation. cfg.sf // 250 keeps each task under ~30 MB at SF=20000 and still 8 at SF≤2000.
+    _sched_target_parts = max(8, cfg.sf // 250)
     schedule_df = schedule_df.coalesce(_sched_target_parts)
 
     # Map action_code → ActionType string so the join key matches all_df.

--- a/src/tools/workflow_builders/augmented_staging.py
+++ b/src/tools/workflow_builders/augmented_staging.py
@@ -381,9 +381,11 @@ def build(*, job_name: str, scale_factor: int, catalog: str,
         stage_files_keys.append(key)
 
     # ---------------- Cleanup: drop the 7 temp Delta tables ----------------
-    # Depends on every leaf in both branches. ALL_DONE so partial-failure
-    # runs still get the cleanup. Not gated by delete_tables_when_finished
-    # because the temp Delta tables are unconditionally temporary.
+    # Depends on every leaf in both branches. ALL_SUCCESS (not ALL_DONE) so
+    # any failed task can be repair-run from the same source data — the
+    # temp Delta tables stay around until everything has succeeded. Not
+    # gated by delete_tables_when_finished because the temp Delta tables
+    # are unconditionally temporary once we're past this point.
     cleanup_deps = stage_files_keys + [
         "DimAccountHistorical", "DimTradeHistorical",
         "FactCashBalancesHistorical", "FactHoldingsHistorical",
@@ -393,7 +395,7 @@ def build(*, job_name: str, scale_factor: int, catalog: str,
         task_key="cleanup_stage0",
         notebook_path=f"{repo_src_path}/tools/augmented_staging/cleanup_stage0",
         depends_on=cleanup_deps,
-        run_if="ALL_DONE",
+        run_if="ALL_SUCCESS",
     ))
 
     # No cleanup-on-failure task needed — the early-exit check uses


### PR DESCRIPTION
## Summary

Bug fixes shaken out by the SF=20k validation pass.

- **`customer.py` — bypass `spark.createDataFrame(pandas_df)` for the CustomerMgmt schedule.** On Spark Connect serverless that path embeds the entire pandas payload into the LogicalPlan as a LocalRelation literal; downstream write tasks then carry the full data set in their serialized plan. At SF=20000 the schedule is ~70M rows × 32 B ≈ 2.2 GB, blowing past `spark.rpc.message.maxSize` (256 MB, NOT settable on serverless) with `Serialized task ... was 494762139 bytes`. Coalesce / repartition can't fix it because the data is in the plan, not in input partitions. Now writes the schedule directly to a Parquet file on the volume via pyarrow (driver-side, no Spark Connect roundtrip), then re-reads with `spark.read.parquet`. Data flows through the FUSE mount instead of the Connect control plane. (`e3a0f50` was an earlier partition-count attempt — kept for log continuity, fully superseded by `1e5d0ab`.)
- **`FactCashBalancesHistorical.sql` — synthesize `cdc_flag` for `cashtransactionhistorical`.** The spark-gen Delta `tpcdi_raw_data.cashtransaction{sf}` doesn't carry a `cdc_flag` column (always `'I'` for CashTransaction; `stage_files/CashTransaction.py` synthesizes it at file-write time). The new INSERT into `cashtransactionhistorical` was SELECTing `cdc_flag` from the source, blowing up with `UNRESOLVED_COLUMN`. Mirror the file-side `'I'` synthesis here.
- **`augmented_staging.py` — `cleanup_stage0` runs `ALL_SUCCESS`, not `ALL_DONE`.** Previously when any leaf task failed, cleanup still dropped the 7 temp Delta tables in `tpcdi_raw_data` — so the failed task couldn't be repair-run because its source data was gone. Flip to `ALL_SUCCESS`: temp Delta survives partial-failure runs, repair just the failed task, then re-trigger.

Validated end-to-end at SF=20000: data_gen 42m, augmented_staging completes, SDP parent benchmark + first incremental pipeline both succeed.

## Test plan

- [x] SF=20000 augmented_staging end-to-end SUCCEEDED (data_gen 42m, all 7 stage_files green, all 6 historical SQL tasks green, cashtransactionhistorical populated, cleanup_stage0 ran)
- [x] SDP-Augmented parent benchmark job SUCCEEDED post-augmented_staging
- [x] First incremental SDP pipeline run after historical phase SUCCEEDED — every silver/gold table received inserts or upserts as expected
- [x] `tests/test_workflow_builders.py` — 14 tests pass

This pull request and its description were written by Isaac.