### PR TITLE
Restore staging_check gate; check consumables, not intermediates

### DIFF
--- a/src/tools/data_gen_tasks/_shared.py
+++ b/src/tools/data_gen_tasks/_shared.py
@@ -53,6 +53,129 @@ def is_already_generated(spark, table_fq: str, expected_min_rows: int = 1) -> bo
         return False
 
 
+# Names of the historical staging tables built by augmented_staging's Stage 1
+# SQL tasks. The benchmark workflows (augmented_classic / _sdp / _dbt) DEEP
+# CLONE these into the benchmark working schema before each run, so they ARE
+# the consumables. If all are present in tpcdi_incremental_staging_{sf}, the
+# historical portion of staging is complete.
+_AUG_STAGING_TABLES = frozenset({
+    # ingest_* outputs (small reference tables)
+    "dimdate", "dimtime", "industry", "statustype", "taxrate", "tradetype",
+    "batchdate",
+    # Silver static dims
+    "dimbroker", "dimcompany", "dimsecurity", "financial",
+    # SCD2 historical dims/facts
+    "dimcustomer", "dimaccount", "dimtrade",
+    "factcashbalances", "factholdings", "factwatches",
+    "companyyeareps", "currentaccountbalances",
+    "dailymarket", "factmarkethistory",
+})
+
+# The 7 augmented-mode datasets that stage_files writes as partitioned CSV
+# trees under {volume_path}/{Dataset}/_pdate=*/part-*.csv (with a _SUCCESS
+# marker at the dataset root). These feed simulate_filedrops in the daily
+# Stage 1 loop.
+_AUG_PARTITIONED_DATASETS = (
+    "Customer", "Account", "Prospect", "Trade", "WatchHistory",
+    "CashTransaction", "DailyMarket",
+)
+
+# Standard-mode (non-augmented) Batch1 files that the single-batch SQL
+# benchmark ingests. Both DIGen-style names (e.g. HR.csv, Customer.txt) and
+# Spark-split forms (HR_1.txt, Customer_1.txt, …) are accepted.
+_STD_BATCH1_FILES = (
+    "HR.csv", "Customer.txt", "Account.txt", "CustomerMgmt.xml",
+    "Prospect.csv", "DailyMarket.txt", "WatchHistory.txt", "Trade.txt",
+    "TradeHistory.txt", "CashTransaction.txt", "HoldingHistory.txt",
+    "BatchDate.txt",
+)
+
+
+def _path_exists(dbutils, path: str) -> bool:
+    try:
+        dbutils.fs.ls(path)
+        return True
+    except Exception:
+        return False
+
+
+def staging_complete_check(spark, dbutils, *, catalog: str, scale_factor,
+                           augmented_incremental: bool, volume_path: str) -> bool:
+    """True if all staging tables/files the benchmark consumes are intact.
+
+    Used by the entry-point data_gen task to decide whether to short-circuit
+    the rest of the workflow (via the `staging_check` condition_task gate).
+
+    What's checked depends on the mode:
+
+    - **augmented_incremental=True** — both halves of Stage 0's output:
+      1. Every historical staging table in
+         ``{catalog}.tpcdi_incremental_staging_{sf}`` is present (the
+         dim/fact tables the benchmark setup notebooks DEEP CLONE from).
+      2. A ``_SUCCESS`` marker exists under each of the 7 partitioned-CSV
+         dataset dirs at ``{volume_path}/{Dataset}/`` (the daily-loop
+         file source).
+
+    - **augmented_incremental=False** — every expected raw file is present
+      in ``{volume_path}/Batch1`` (either as the DIGen single-file name or
+      the Spark-split form ``{stem}_N.{ext}``).
+
+    Intentionally does NOT check the cross-task intermediates in
+    ``{wh_db}_{sf}_stage`` — those get dropped by ``cleanup_intermediates``
+    at the end of every successful run, so they'd always look "missing" on
+    a re-trigger even when nothing needs regeneration.
+    """
+    if augmented_incremental:
+        # 1. Historical staging tables
+        staging_schema = f"{catalog}.tpcdi_incremental_staging_{scale_factor}"
+        try:
+            present = {r["tableName"] for r in
+                       spark.sql(f"SHOW TABLES IN {staging_schema}").collect()}
+        except Exception as e:
+            print(f"[staging_check] {staging_schema} not queryable "
+                  f"({type(e).__name__}: {e}) — treating as incomplete")
+            return False
+        missing = _AUG_STAGING_TABLES - present
+        if missing:
+            print(f"[staging_check] {staging_schema} missing tables: "
+                  f"{sorted(missing)}")
+            return False
+        # 2. Partitioned CSV trees with _SUCCESS markers
+        for dataset in _AUG_PARTITIONED_DATASETS:
+            marker = f"{volume_path.rstrip('/')}/{dataset}/_SUCCESS"
+            if not _path_exists(dbutils, marker):
+                print(f"[staging_check] missing _SUCCESS marker: {marker}")
+                return False
+        print(f"[staging_check] augmented staging intact: "
+              f"{len(_AUG_STAGING_TABLES)} tables in {staging_schema}, "
+              f"{len(_AUG_PARTITIONED_DATASETS)} partitioned CSV trees")
+        return True
+    else:
+        # Standard mode: check Batch1 raw files (the single-batch SQL
+        # benchmark consumes from here). Accept either DIGen-style single
+        # filenames or Spark-split forms (Customer_1.txt, Customer_2.txt, …).
+        batch1 = f"{volume_path.rstrip('/')}/Batch1"
+        try:
+            existing = {f.name.rstrip("/") for f in dbutils.fs.ls(batch1)}
+        except Exception as e:
+            print(f"[staging_check] {batch1} not listable "
+                  f"({type(e).__name__}: {e}) — treating as incomplete")
+            return False
+        for filename in _STD_BATCH1_FILES:
+            stem, _, ext = filename.rpartition(".")
+            split_prefix = f"{stem}_"
+            if filename in existing or any(
+                f.startswith(split_prefix) and f.endswith(f".{ext}")
+                for f in existing
+            ):
+                continue
+            print(f"[staging_check] missing from {batch1}: {filename}")
+            return False
+        print(f"[staging_check] standard-mode Batch1 intact "
+              f"({len(_STD_BATCH1_FILES)} expected files)")
+        return True
+
+
 def write_intermediate_delta(df, *, catalog: str, wh_db: str, scale_factor,
                              name: str, partition_cols: list = None) -> str:
     """Write ``df`` as a Delta temp table in ``{wh_db}_{sf}_stage``.

--- a/src/tools/data_gen_tasks/data_gen.py
+++ b/src/tools/data_gen_tasks/data_gen.py
@@ -78,7 +78,7 @@ if data_gen_type == "native":
 
 # Spark / augmented_incremental branch: init the cross-task intermediates.
 # Downstream gen_* / copy_* / audit_emit / cleanup_intermediates do the rest.
-from data_gen_tasks._shared import bootstrap, stage_schema_fq
+from data_gen_tasks._shared import bootstrap, stage_schema_fq, staging_complete_check
 
 ctx = bootstrap(spark=spark, dbutils=dbutils, scale_factor=scale_factor,
                 catalog=catalog, wh_db=wh_db, tpcdi_directory=tpcdi_directory,
@@ -149,9 +149,32 @@ if augmented_incremental and generate_bronze_staging == "YES" and regenerate_dat
         print(f"[data_gen] generate_bronze_staging=YES and all 7 bronze tables "
               f"already exist in {_staging_schema} — honoring raw regenerate_data=NO")
 
-if regenerate_data == "YES":
-    # Wipe the volume's per-SF tree, drop intermediates and dataset Deltas.
-    print(f"[data_gen] regenerate_data=YES → wiping {cfg.volume_path}")
+# Compute whether the benchmark-consumable staging output (NOT the
+# intermediates) is already intact. The downstream `staging_check`
+# condition_task gate reads the `staging_complete` task value this sets
+# below to short-circuit the rest of the workflow when everything's ready.
+# We always recompute even on regenerate_data=YES so the wipe-and-rebuild
+# decision is logged uniformly.
+_staging_complete = staging_complete_check(
+    spark, dbutils,
+    catalog=catalog,
+    scale_factor=scale_factor,
+    augmented_incremental=augmented_incremental,
+    volume_path=cfg.volume_path,
+)
+
+# Regenerate when explicitly requested OR when staging is incomplete (a
+# half-failed prior run, or a brand-new SF). In either case we wipe everything
+# stale first so the rebuild starts from a known-clean state — leftover
+# UniForm-enabled tables otherwise block plain-Delta CREATE OR REPLACE.
+_should_regenerate = (regenerate_data == "YES") or (not _staging_complete)
+
+if _should_regenerate:
+    if regenerate_data == "YES":
+        print(f"[data_gen] regenerate_data=YES → wiping {cfg.volume_path}")
+    else:
+        print(f"[data_gen] staging incomplete → wiping {cfg.volume_path} "
+              f"before rebuild")
     try:
         dbutils.fs.rm(cfg.volume_path, recurse=True)
     except Exception as e:
@@ -192,8 +215,16 @@ if regenerate_data == "YES":
         except Exception as e:
             print(f"[data_gen] {incr_schema} not present or empty: {type(e).__name__}: {e}")
 else:
-    print(f"[data_gen] regenerate_data=NO → keeping prior state for "
-          f"per-task self-skip")
+    print(f"[data_gen] regenerate_data=NO and staging intact → "
+          f"signaling staging_check to skip downstream tasks")
+
+# Emit the task value the downstream `staging_check` condition_task reads.
+# String literal because dbutils.jobs.taskValues stringifies booleans as
+# "true"/"false" — explicit match keeps the condition unambiguous.
+dbutils.jobs.taskValues.set(
+    "staging_complete",
+    "true" if (not _should_regenerate) else "false",
+)
 
 # COMMAND ----------
 

--- a/src/tools/workflow_builders/augmented_staging.py
+++ b/src/tools/workflow_builders/augmented_staging.py
@@ -188,12 +188,32 @@ def build(*, job_name: str, scale_factor: int, catalog: str,
         notebook_path=f"{_dgt_path}/data_gen",
         base_params=_dgt_params,
     ))
-    # Wave 1 — no upstream gen dependencies.
+    # staging_check: condition_task gate that short-circuits everything below
+    # when data_gen reports staging_complete=true. The check looks at the
+    # benchmark consumables (tpcdi_incremental_staging_{sf} tables + the
+    # partitioned-CSV _SUCCESS markers), NOT the cross-task intermediates
+    # (which get dropped by cleanup_intermediates at end of every clean run).
+    # Outcome=true means "staging is incomplete, run the gens"; outcome=false
+    # cascades skips through every downstream task via run_if=ALL_SUCCESS.
+    tasks.append({
+        "task_key": "staging_check",
+        "depends_on": [{"task_key": "data_gen"}],
+        "run_if": "ALL_SUCCESS",
+        "condition_task": {
+            "op": "EQUAL_TO",
+            "left": "{{tasks.data_gen.values.staging_complete}}",
+            "right": "false",
+        },
+        "timeout_seconds": 0,
+        "email_notifications": {},
+        "webhook_notifications": {},
+    })
+    # Wave 1 — no upstream gen dependencies. Gated by staging_check[true].
     for _name in ("gen_reference", "gen_hr", "gen_finwire"):
         tasks.append(_make_task(
             task_key=_name,
             notebook_path=f"{_dgt_path}/{_name}",
-            depends_on=["data_gen"],
+            depends_on=[{"task_key": "staging_check", "outcome": "true"}],
             base_params=_dgt_params,
         ))
     # Wave 2 — depends on a wave-1 producer.
@@ -266,11 +286,11 @@ def build(*, job_name: str, scale_factor: int, catalog: str,
         base_params={**_wh_param},
     ))
 
-    # No staging_check gate — each Stage 1 task wires directly to the
-    # specific gen / copy task that produces its source data, so they
-    # start as soon as their actual inputs are ready (no synthetic
-    # all-gens-done barrier). Per-task self-skip in each gen handles the
-    # repair-friendly short-circuit.
+    # Stage 1 raw_ingestion / silver / historical tasks below depend on
+    # specific upstream gens / copies (not on data_gen directly), so when
+    # staging_check[outcome=false] cascades skips through the gen DAG,
+    # those skips propagate naturally through every downstream task via
+    # run_if=ALL_SUCCESS.
 
     # ---------------- Stage 1a: raw_ingestion ----------------
     raw_ingest_path = f"{repo_src_path}/single_batch/SQL/raw_ingestion"

--- a/src/tools/workflow_builders/datagen_spark.py
+++ b/src/tools/workflow_builders/datagen_spark.py
@@ -227,12 +227,29 @@ def build(*, job_name: str, scale_factor: int, catalog: str,
         base_params=_base,
         job_cluster_key=job_cluster_key,
     ))
-    # Wave 1 — no upstream gen.
+    # staging_check: condition_task gate that short-circuits the entire gen
+    # DAG when data_gen reports staging_complete=true. Outcome=true means
+    # "staging is incomplete, run the gens"; outcome=false cascades skips
+    # through every downstream task via run_if=ALL_SUCCESS.
+    tasks.append({
+        "task_key": "staging_check",
+        "depends_on": [{"task_key": "data_gen"}],
+        "run_if": "ALL_SUCCESS",
+        "condition_task": {
+            "op": "EQUAL_TO",
+            "left": "{{tasks.data_gen.values.staging_complete}}",
+            "right": "false",
+        },
+        "timeout_seconds": 0,
+        "email_notifications": {},
+        "webhook_notifications": {},
+    })
+    # Wave 1 — no upstream gen. Gated by staging_check[true].
     for _name in ("gen_reference", "gen_hr", "gen_finwire", "gen_prospect"):
         tasks.append(_make_task(
             task_key=_name,
             notebook_path=f"{_dgt}/{_name}",
-            depends_on=["data_gen"],
+            depends_on=[{"task_key": "staging_check", "outcome": "true"}],
             base_params=_base,
             job_cluster_key=job_cluster_key,
         ))

--- a/tests/test_workflow_builders.py
+++ b/tests/test_workflow_builders.py
@@ -63,6 +63,17 @@ def test_datagen_spark():
     _ok(f"tag = {out['tags']}")
     assert "_DataGen" not in out["name"], "old _DataGen suffix leaked"
     _ok("no _DataGen suffix")
+    # staging_check gate between data_gen and wave-1 gens.
+    by_key = {t["task_key"]: t for t in out["tasks"]}
+    assert "staging_check" in by_key, "staging_check condition_task missing"
+    sc = by_key["staging_check"]
+    assert sc["condition_task"]["left"] == "{{tasks.data_gen.values.staging_complete}}"
+    assert sc["condition_task"]["right"] == "false"
+    for _w1 in ("gen_reference", "gen_hr", "gen_finwire", "gen_prospect"):
+        deps = by_key[_w1]["depends_on"]
+        assert any(d.get("task_key") == "staging_check" and d.get("outcome") == "true"
+                   for d in deps), f"{_w1} should depend on staging_check[outcome=true]"
+    _ok("staging_check gates wave-1 gens")
 
 
 def test_datagen_native():
@@ -501,10 +512,21 @@ def test_augmented_staging_dag():
     _ok("cleanup_intermediates depends on all gens")
     assert by_key["cleanup_intermediates"]["run_if"] == "ALL_SUCCESS"
     _ok("cleanup_intermediates runs ALL_SUCCESS")
-    # staging_check is gone — Stage 1 tasks wire directly to gen/copy.
-    assert "staging_check" not in keys, \
-        "staging_check should be removed; Stage 1 tasks wire to gen/copy directly"
-    _ok("staging_check removed")
+    # staging_check condition_task gates wave-1 gens so the whole DAG
+    # short-circuits when data_gen reports staging_complete=true.
+    assert "staging_check" in keys, "staging_check condition_task missing"
+    sc = by_key["staging_check"]
+    assert sc.get("condition_task", {}).get("op") == "EQUAL_TO"
+    assert sc["condition_task"]["left"] == "{{tasks.data_gen.values.staging_complete}}"
+    assert sc["condition_task"]["right"] == "false"
+    sc_deps = {d["task_key"] for d in sc["depends_on"]}
+    assert sc_deps == {"data_gen"}, f"staging_check should depend on data_gen, got {sc_deps}"
+    for _w1 in ("gen_reference", "gen_hr", "gen_finwire"):
+        deps = by_key[_w1]["depends_on"]
+        assert any(d.get("task_key") == "staging_check" and d.get("outcome") == "true"
+                   for d in deps), \
+            f"{_w1} should depend on staging_check[outcome=true], got {deps}"
+    _ok("staging_check gates wave-1 gens on outcome=true")
     # Spot-check Stage 1 wiring: stage_files_DailyMarket → gen_daily_market.
     sf_dm_deps = {d["task_key"] for d in by_key["stage_files_DailyMarket"]["depends_on"]}
     assert sf_dm_deps == {"gen_daily_market"}, \


### PR DESCRIPTION
## Summary

When commit `bf6d53d` removed the historical `staging_check` condition_task, the design shifted to per-task self-skip. But three gen_* tasks (`gen_hr`, `gen_finwire`, `gen_trade_base`) check **intermediate** `_gen_*` Delta tables — which `cleanup_intermediates` drops at the end of every successful run. So re-triggering `data_gen` with `regenerate_data=NO` always made those three rebuild, cascading into a full regeneration even when nothing was stale.

This PR:
- **Restores the workflow-level gate** as a `staging_check` condition_task between `data_gen` and the wave-1 gens. Wave-1 gens depend on `outcome=true`; skips cascade through the entire DAG via `run_if=ALL_SUCCESS`.
- **Rewrites the completeness check** to look at what the benchmark actually consumes:
  - Augmented: ~21 historical tables in `tpcdi_incremental_staging_{sf}` + `_SUCCESS` markers under each of 7 partitioned-CSV staging dirs (the daily-loop file source).
  - Standard: expected raw files in `Batch1/` (DIGen single-file names or Spark split-form `{stem}_N.{ext}` both accepted).
- **Adds clean-slate behavior** on the wipe path. When data_gen decides to regenerate (either `regenerate_data=YES` OR staging incomplete), it wipes everything stale: volume files, `_stage` schema tables, `tpcdi_raw_data.{dataset}{sf}` Deltas, and `tpcdi_incremental_staging_{sf}` tables. This avoids the `IcebergCompat cannot be disabled` failure on `CREATE OR REPLACE` against UniForm-enabled leftover tables.

Files changed:
- `src/tools/data_gen_tasks/_shared.py` — new `staging_complete_check()` helper
- `src/tools/data_gen_tasks/data_gen.py` — calls the check; emits `staging_complete` task value; wipes when regenerating
- `src/tools/workflow_builders/augmented_staging.py` — inserts `staging_check` condition_task; rewires wave-1 gens
- `src/tools/workflow_builders/datagen_spark.py` — same gate pattern for standard mode
- `tests/test_workflow_builders.py` — flipped the obsolete "staging_check should be removed" assertion; added analogous assertion for `test_datagen_spark`

## Test plan

- [x] `pytest tests/test_workflow_builders.py` — all 17 tests pass locally
- [ ] SF=10 augmented data_gen, fresh workspace: trigger with `regenerate_data=NO` → expect full DAG runs
- [ ] Re-trigger same job with `regenerate_data=NO` → expect `data_gen` succeeds in ~5s and all downstream tasks **SKIPPED**
- [ ] Trigger with `regenerate_data=YES` → expect `data_gen` wipes (volume + `_stage` + `tpcdi_raw_data` Deltas + `tpcdi_incremental_staging_{sf}` tables) then full DAG runs

This pull request and its description were written by Isaac.