### PR TITLE
Fix dbt warehouse arg keys (name/size → wh_name/wh_size)

### DIFF
--- a/src/tools/generate_benchmark_workflow.py
+++ b/src/tools/generate_benchmark_workflow.py
@@ -120,7 +120,7 @@ def _generate_augmented(*, variant: str, parent_job_name: str,
         # task type runs commands against it. Warehouse name follows the same
         # pattern as the rest of the augmented workflow.
         wh_name = f"{wh_target}-tpcdi-dbt"
-        wh_dag_args = {"name": wh_name, "size": _dbt_wh_size(scale_factor)}
+        wh_dag_args = {"wh_name": wh_name, "wh_size": _dbt_wh_size(scale_factor)}
         wh_id = _get_or_create_warehouse(wh_name, wh_dag_args, workspace_src_path, api_call)
         print(f"  warehouse:      {wh_name} ({wh_id})")
         print()


### PR DESCRIPTION
## Summary

`generate_benchmark_workflow.py` was building `wh_dag_args` with keys `"name"` / `"size"` for the augmented_incremental DBT path, but `workflow_builders.warehouse.build()` declares keyword-only args `wh_name` and `wh_size`. The wrong-named keys fell into `**_unused`, leaving the required keyword args unfilled and raising `TypeError: build() missing 2 required keyword-only arguments: 'wh_name' and 'wh_size'` whenever the dbt warehouse needed to be created on a fresh workspace.

One-line fix: rename the dict keys to match the function signature. The other call site (line 355, the non-augmented DBT/STMV/DBSQL path) already uses the correct keys via `dag_args["wh_name"]` / `dag_args["wh_size"]`.

## Test plan

- [x] `pytest tests/test_workflow_builders.py` — 17 tests pass
- [x] Smoke-tested `warehouse.build(wh_name="…", wh_size="…")` returns a valid payload
- [ ] Trigger TPC-DI Driver with SKU=dbt on a fresh workspace where the dbt warehouse doesn't yet exist; expect creation to succeed.

This pull request and its description were written by Isaac.