### PR TITLE
Concise pass (proving ground): trim war-story comments in Redshift port

### DIFF
--- a/src/incremental_batches/augmented_incremental/redshift/_rs_conn.py
+++ b/src/incremental_batches/augmented_incremental/redshift/_rs_conn.py
@@ -112,7 +112,7 @@ def rs_iam_role(*, secret_scope: str = "tpcdi_redshift") -> str:
     """Return the IAM role ARN used by Redshift COPY statements.
 
     Pulled from the secret scope so the workgroup identity stays out of
-    source code. Used by `load_bronze_rs` and `setup_rs` when issuing
+    source code. Used by setup_rs and the dbt bronze pre_hooks when issuing
     `COPY ... IAM_ROLE '<arn>' ...`.
     """
     try:

--- a/src/incremental_batches/augmented_incremental/redshift/_rs_conn.py
+++ b/src/incremental_batches/augmented_incremental/redshift/_rs_conn.py
@@ -86,12 +86,8 @@ def rs_connect(*, database: str | None = None,
     conn = psycopg2.connect(
         host=host, port=port, user=user, password=password,
         dbname=dbname, sslmode="require", connect_timeout=30,
-        # TCP keepalives: OS sends probes so an idle SSL socket doesn't
-        # silently close mid-pipeline. We hit "SSL connection has been
-        # closed unexpectedly" on the SF=20k bootstrap (80 min idle on
-        # conn while parallel workers seeded big tables on their own
-        # connections). Probes start after 30s idle, retry 3x at 10s
-        # spacing.
+        # TCP keepalives (probe after 30s idle, 3x at 10s) so a long-idle
+        # socket isn't silently dropped mid-pipeline by Redshift Serverless.
         keepalives=1, keepalives_idle=30,
         keepalives_interval=10, keepalives_count=3,
     )

--- a/src/incremental_batches/augmented_incremental/redshift/rs_staging_bootstrap.py
+++ b/src/incremental_batches/augmented_incremental/redshift/rs_staging_bootstrap.py
@@ -1,35 +1,18 @@
-"""
-rs_staging_bootstrap.py — self-bootstrapping Redshift staging schema.
+"""Self-bootstrapping Redshift staging schema (pure Python module, imported
+by setup_rs.py — mirrors bq_/sf_staging_bootstrap.py).
 
-Pure Python module (NOT a notebook). Mirrors `bq_staging_bootstrap.py` and
-`sf_staging_bootstrap.py`. Entry point is called by `setup_rs.py` within the
-same notebook execution (NOT via dbutils.notebook.run — see
-[[feedback-no-dbutils-notebook-run]]):
+`ensure_staging_environment(...)` is idempotent: it seeds only the staging
+tables that are missing or empty, each via Delta -> parquet (UC external
+volume on S3) -> COPY -> row-count parity check.
 
-  ensure_staging_environment(conn, *, database, target_schema, src_catalog,
-                              src_schema, parquet_root, volume_root,
-                              s3_volume_prefix, iam_role, aws_region,
-                              spark, dbutils, secret_scope, parallel=4) -> dict
-    Idempotent. Checks Redshift `{database}.{target_schema}` exists with all
-    22 expected staging tables. If anything is missing, seeds only the
-    missing ones in parallel via Delta → parquet (UC external volume on S3)
-    → COPY into Redshift → row-count parity check.
-
-Per-table layout (DISTKEY / SORTKEY / DISTSTYLE) declared at CREATE time —
-mirrors the strategy in setup_rs.py's per-run CTAS layouts (PORT_NOTES.md
-"DISTKEY / SORTKEY strategy" section).
-
-Type mapping: Spark's `DataType.simpleString()` keys (bigint/smallint/
-tinyint/int/etc.) NOT internal Python names — Redshift COPY FROM PARQUET
-requires exact type match.
+Tables are sorted biggest-first so the thread pool starts the long-pole
+loads first. Layouts (DISTKEY/SORTKEY) match setup_rs.py's TABLE_LAYOUTS.
 """
 from __future__ import annotations
 
 import concurrent.futures as _cf
 import time as _time
 
-# Canonical 22 staging tables (same set as bq_staging_bootstrap.STAGING_TABLES,
-# sorted biggest-first so the ThreadPoolExecutor kicks off long-pole tables first).
 STAGING_TABLES: tuple[str, ...] = (
     "bronzedailymarket", "factmarkethistory",
     "factwatches",
@@ -45,10 +28,8 @@ STAGING_TABLES: tuple[str, ...] = (
     "statustype", "batchdate",
 )
 
-# Per-table Redshift layout. Spec format: (distribution_spec, sortkey_cols).
-# distribution_spec: "ALL" | "EVEN" | "KEY(col)"
-# Keep in sync with setup_rs.py's TABLE_LAYOUTS — both point at the same
-# physical tables (staging is the CTAS source for the per-run schema).
+# (distribution_spec, sortkey_cols) per table. Keep in sync with setup_rs.py's
+# TABLE_LAYOUTS — staging is the CTAS source for the per-run schema.
 TABLE_LAYOUTS: dict[str, tuple[str, tuple[str, ...]]] = {
     "factmarkethistory":          ("KEY(sk_securityid)", ("sk_dateid", "sk_securityid", "sk_companyid")),
     "factwatches":                ("KEY(sk_customerid)", ("sk_dateid_dateremoved", "sk_customerid", "sk_securityid")),
@@ -77,17 +58,16 @@ _missing_layouts = set(STAGING_TABLES) - set(TABLE_LAYOUTS)
 assert not _missing_layouts, f"TABLE_LAYOUTS missing: {_missing_layouts}"
 
 
-# Redshift COPY FROM PARQUET requires EXACT type match. Map keys MUST match
-# Spark `DataType.simpleString()` output (SQL-flavored: bigint/int/smallint/
-# tinyint), NOT internal Python type names.
+# COPY FROM PARQUET needs an exact type match, so keys are Spark
+# DataType.simpleString() values (SQL-flavored), not Python type names.
 _TYPE_MAP: dict[str, str] = {
     "boolean":    "BOOLEAN",
     "tinyint":    "SMALLINT",            # Redshift has no TINYINT
     "smallint":   "SMALLINT",
     "int":        "INTEGER",
     "bigint":     "BIGINT",
-    "float":      "REAL",                # parquet FLOAT (32-bit) → REAL/FLOAT4
-    "double":     "DOUBLE PRECISION",    # parquet DOUBLE (64-bit) → FLOAT8
+    "float":      "REAL",                # parquet FLOAT (32-bit) -> REAL
+    "double":     "DOUBLE PRECISION",    # parquet DOUBLE (64-bit) -> FLOAT8
     "date":       "DATE",
     "timestamp":  "TIMESTAMP",
     "binary":     "VARBYTE",
@@ -99,9 +79,7 @@ def _dist_clause(spec: str) -> str:
     if spec == "EVEN": return "DISTSTYLE EVEN"
     if spec.startswith("KEY("):
         col = spec[len("KEY("):-1]
-        # `DISTKEY(col)` alone implies `DISTSTYLE KEY` — cleaner than
-        # writing both. Writing `DISTSTYLE KEY KEY(col)` is a syntax error.
-        return f"DISTKEY({col})"
+        return f"DISTKEY({col})"  # implies DISTSTYLE KEY
     raise ValueError(f"unknown distribution_spec: {spec}")
 
 
@@ -133,16 +111,9 @@ def _seed_one(table: str, *, database: str, target_schema: str,
               parquet_root: str, volume_root: str, s3_volume_prefix: str,
               iam_role: str, aws_region: str,
               spark, dbutils, secret_scope: str) -> dict:
-    """Seed one staging table: Delta → parquet → COPY → row-count check.
-
-    Each call opens its own psycopg2 connection (psycopg2 connections are
-    NOT thread-safe to share, so per-thread is the rule). Raises on any
-    failure — caller catches and aggregates.
-
-    NOTE: do NOT do relative imports here. This module is loaded via
-    sys.path insertion (not as a package), so `from . import X` fails
-    immediately with "attempted relative import with no known parent
-    package". Use absolute imports only.
+    """Seed one staging table: Delta -> parquet -> COPY -> row-count check.
+    Opens its own psycopg2 connection (they aren't thread-safe to share).
+    Raises on failure; the caller aggregates.
     """
     import psycopg2
 
@@ -166,11 +137,9 @@ def _seed_one(table: str, *, database: str, target_schema: str,
     log.append(f"[{table}] delta_rows={delta_rows:,}")
     df.write.mode("overwrite").parquet(pq_path)
 
-    # Spark on UC volumes leaves `_committed_*` and `_SUCCESS` markers
-    # alongside part files. Redshift COPY treats them as parquet and fails
-    # with "Spectrum Scan Error / invalid version number". Defense in depth:
-    #   (1) delete the markers, (2) use `/part-` COPY URI prefix so any
-    #   leftover markers can't match.
+    # Spark leaves `_committed_*` / `_SUCCESS` markers next to the part files;
+    # COPY would try to read them as parquet and fail. Delete them, and point
+    # COPY at the `/part-` prefix so any stragglers can't match.
     try:
         for entry in dbutils.fs.ls(pq_path):
             if entry.name.rstrip("/").startswith("_"):
@@ -201,8 +170,8 @@ def _seed_one(table: str, *, database: str, target_schema: str,
             """)
             cur.execute(f'SELECT COUNT(*) FROM "{target_schema}"."{table}"')
             rs_rows = cur.fetchone()[0]
-            # Record expected row count in a TABLE COMMENT so future setup_rs
-            # runs can detect partial seeds without re-counting Delta.
+            # Stamp the row count in a TABLE COMMENT so a later run can detect
+            # a partial/empty seed without re-reading Delta.
             cur.execute(
                 f"COMMENT ON TABLE \"{target_schema}\".\"{table}\" "
                 f"IS 'tpcdi_staging_seed: rows={rs_rows}'"
@@ -234,63 +203,41 @@ def ensure_staging_environment(conn, *,
                                 dbutils,
                                 secret_scope: str,
                                 parallel: int = 8) -> dict:
-    """Idempotent Redshift staging bootstrap. Mirrors
-    `bq_staging_bootstrap.ensure_staging_environment` and
-    `sf_staging_bootstrap.ensure_staging_environment`.
+    """Idempotent Redshift staging bootstrap (mirrors the bq_/sf_ equivalents).
 
     Args:
-        conn: live psycopg2 connection (autocommit OK either way).
+        conn: live psycopg2 connection.
         database: Redshift database name (e.g. "dev").
         target_schema: per-SF staging schema (e.g. "tpcdi_staging_sf10").
-        src_catalog / src_schema: Databricks-side source
-          (e.g. "main" / "tpcdi_incremental_staging_{sf}").
+        src_catalog / src_schema: Databricks source (catalog / schema).
         parquet_root: UC volume path for the per-table parquet staging step.
-        volume_root: UC volume root used for s3_uri rewrite.
+        volume_root: UC volume root, rewritten to s3_volume_prefix for COPY.
         s3_volume_prefix: s3:// prefix that maps 1:1 to volume_root.
-        iam_role: IAM role ARN attached to the workgroup, for COPY.
-        aws_region: COPY's REGION clause.
-        spark: SparkSession.
-        dbutils: notebook dbutils for fs.ls/fs.rm/secrets.
-        secret_scope: scope name to load psycopg2 creds in worker threads.
-        parallel: ThreadPoolExecutor max_workers (default 8 — matches sf).
+        iam_role: IAM role ARN for COPY.
+        aws_region: COPY REGION clause.
+        spark / dbutils: notebook handles.
+        secret_scope: scope for psycopg2 creds in worker threads.
+        parallel: thread-pool size.
 
     Returns:
-        dict: {skipped: bool, n_seeded: int, elapsed_s: float, missing: list}.
+        {skipped, n_seeded, elapsed_s, missing}.
 
     Raises:
-        RuntimeError if any seeded table fails to load with matching row counts.
+        RuntimeError if any seeded table's row count doesn't match its source.
     """
-    # 1) Ensure schema exists.
     with conn.cursor() as cur:
         cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{target_schema}"')
 
-    # 2) Check what's already present AND non-empty. Plain `table_exists` is
-    #    not enough — a prior cancelled run can leave behind tables that were
-    #    CREATE TABLE'd but for which the COPY never completed. Those shells
-    #    pass the existence test and get skipped, then the downstream CTAS
-    #    copies an empty table into the per-run schema. We hit this exact
-    #    failure mode on the SF=20k re-run: factmarkethistory CTAS'd in 1.86s
-    #    (should have been multiple minutes for ~6B rows) because the staging
-    #    table was empty.
     with conn.cursor() as cur:
         cur.execute(
             "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
             (target_schema,),
         )
         present = {r[0].lower() for r in cur.fetchall()}
-    # Verify row count parity for each "present" table. _seed_one records the
-    # expected row count as a TABLE COMMENT on successful seed; we read it
-    # back here and compare to the actual count.
-    #
-    # Failure modes we catch:
-    #   1. Present but empty (CREATE TABLE ran, COPY never did — what we
-    #      observed after the SF=20k cancel). Caught by `actual > 0`.
-    #   2. Present but partial (theoretical — Redshift COPY is autocommit so
-    #      rollback should be all-or-nothing). Caught by `actual == expected`.
-    #   3. Present but mutated externally (DELETE, INSERT). Caught by `==`.
-    #
-    # Tables without a COMMENT (legacy seed before this hardening landed)
-    # fall through to the `actual > 0` check.
+    # A table counts as seeded only if its actual row count matches the count
+    # _seed_one stamped in its TABLE COMMENT — existence alone isn't enough,
+    # since a cancelled run can leave a CREATE'd-but-never-COPY'd empty shell.
+    # Tables without the comment marker (legacy seeds) fall back to `> 0`.
     import re as _re
     nonempty = set()
     with conn.cursor() as cur:
@@ -328,7 +275,7 @@ def ensure_staging_environment(conn, *,
         print(msg)
         return {"skipped": True, "n_seeded": 0, "elapsed_s": 0.0, "missing": []}
 
-    # 3) Seed only the missing tables in parallel.
+    # Seed only the missing tables, in parallel.
     print(f"[bootstrap] seeding {len(missing)} of {len(STAGING_TABLES)} staging tables: {missing}")
     t_start = _time.time()
     results: list[dict] = []
@@ -366,13 +313,9 @@ def ensure_staging_environment(conn, *,
     elapsed_s = _time.time() - t_start
     print(f"\n[bootstrap] seeded {len(results)} tables, {len(failures)} failures in {elapsed_s:.1f}s")
 
-    # 4) Re-verify after seed. CRITICAL: the original `conn` was opened in
-    #    setup_rs.py before this function ran, and has been idle for the
-    #    entire bootstrap duration. At SF=20k that's 30-80 minutes — far
-    #    longer than Redshift Serverless's SSL keepalive. Re-using `conn`
-    #    here raises "SSL connection has been closed unexpectedly".
-    #
-    #    Open a fresh short-lived connection just for the verify check.
+    # Re-verify on a fresh connection: the caller's `conn` has been idle for
+    # the whole (up to ~1hr) seed and Redshift Serverless would have dropped
+    # its SSL socket by now.
     import psycopg2 as _psy
     def _get_secret(k, default=None):
         try: return dbutils.secrets.get(scope=secret_scope, key=k)

--- a/src/incremental_batches/augmented_incremental/redshift/rs_staging_bootstrap.py
+++ b/src/incremental_batches/augmented_incremental/redshift/rs_staging_bootstrap.py
@@ -1,12 +1,13 @@
-"""Self-bootstrapping Redshift staging schema (pure Python module, imported
-by setup_rs.py — mirrors bq_/sf_staging_bootstrap.py).
+"""Self-bootstrapping Redshift staging schema.
 
-`ensure_staging_environment(...)` is idempotent: it seeds only the staging
-tables that are missing or empty, each via Delta -> parquet (UC external
-volume on S3) -> COPY -> row-count parity check.
+Pure Python module imported by setup_rs.py; mirrors bq_/sf_staging_bootstrap.py.
 
-Tables are sorted biggest-first so the thread pool starts the long-pole
-loads first. Layouts (DISTKEY/SORTKEY) match setup_rs.py's TABLE_LAYOUTS.
+`ensure_staging_environment(...)` is idempotent.
+It seeds only the staging tables that are missing or empty, each via
+Delta -> parquet (UC external volume on S3) -> COPY -> row-count parity check.
+
+Tables are sorted biggest-first so the thread pool starts the long-pole loads
+first. Layouts (DISTKEY/SORTKEY) match setup_rs.py's TABLE_LAYOUTS.
 """
 from __future__ import annotations
 
@@ -112,6 +113,7 @@ def _seed_one(table: str, *, database: str, target_schema: str,
               iam_role: str, aws_region: str,
               spark, dbutils, secret_scope: str) -> dict:
     """Seed one staging table: Delta -> parquet -> COPY -> row-count check.
+
     Opens its own psycopg2 connection (they aren't thread-safe to share).
     Raises on failure; the caller aggregates.
     """
@@ -235,8 +237,9 @@ def ensure_staging_environment(conn, *,
         )
         present = {r[0].lower() for r in cur.fetchall()}
     # A table counts as seeded only if its actual row count matches the count
-    # _seed_one stamped in its TABLE COMMENT — existence alone isn't enough,
-    # since a cancelled run can leave a CREATE'd-but-never-COPY'd empty shell.
+    # _seed_one stamped in its TABLE COMMENT.
+    # Existence alone isn't enough: a cancelled run can leave a
+    # CREATE'd-but-never-COPY'd empty shell.
     # Tables without the comment marker (legacy seeds) fall back to `> 0`.
     import re as _re
     nonempty = set()
@@ -313,9 +316,9 @@ def ensure_staging_environment(conn, *,
     elapsed_s = _time.time() - t_start
     print(f"\n[bootstrap] seeded {len(results)} tables, {len(failures)} failures in {elapsed_s:.1f}s")
 
-    # Re-verify on a fresh connection: the caller's `conn` has been idle for
-    # the whole (up to ~1hr) seed and Redshift Serverless would have dropped
-    # its SSL socket by now.
+    # Re-verify on a fresh connection.
+    # The caller's `conn` has been idle for the whole (up to ~1hr) seed, so
+    # Redshift Serverless would have dropped its SSL socket by now.
     import psycopg2 as _psy
     def _get_secret(k, default=None):
         try: return dbutils.secrets.get(scope=secret_scope, key=k)

--- a/src/incremental_batches/augmented_incremental/redshift/run_dbt.py
+++ b/src/incremental_batches/augmented_incremental/redshift/run_dbt.py
@@ -109,11 +109,9 @@ lines = [
     f"      user: {rs_user}",
     f"      password: {rs_password}",
     "      threads: 8",
-    # connect_timeout in dbt-redshift is passed as the underlying socket
-    # timeout for redshift_connector. Default 30s killed SF=10 bronzes
-    # at 30-36s (XS workgroup cold-start latency). Larger SFs have
-    # individual queries that legitimately take 10-20 min, so 3600 (1 hr)
-    # gives headroom without hiding real hangs.
+    # dbt-redshift passes connect_timeout as the socket timeout, so it also
+    # caps individual query duration, not just connect.
+    # Large-SF queries can legitimately run 10-20 min, so use 1 hr.
     "      connect_timeout: 3600",
     "      sslmode: require",
 ]
@@ -144,10 +142,9 @@ vars_payload = {
     "aws_region":       aws_region,
     "file_ext":         file_ext,
 }
-# Invoke dbt IN-PROCESS via dbtRunner (the documented Python API).
-# Avoids subprocess + serverless env_version=5 venv inheritance issues that
-# make `python -m dbt.cli.main` fail with "No module named 'dbt.cli'" even
-# though dbt-redshift is importable in the notebook's own Python process.
+# Invoke dbt in-process via dbtRunner (the documented Python API).
+# A subprocess `python -m dbt.cli.main` doesn't inherit the serverless
+# env_version=5 venv, so it can't find dbt even when it's importable here.
 from dbt.cli.main import dbtRunner
 
 dbt_args = [
@@ -172,10 +169,8 @@ try:
     if result.exception:
         summary_lines.append(f"# exception: {type(result.exception).__name__}: {result.exception}")
     if result.result:
-        # result.result is a RunExecutionResult — iterate nodes; include
-        # the per-node message (which holds the SQL error text for
-        # failed nodes) so the log captures actionable detail rather
-        # than just status + timing.
+        # Include each node's message (holds the SQL error text on failure)
+        # so the log has actionable detail, not just status + timing.
         for node_result in getattr(result.result, "results", []):
             summary_lines.append(
                 f"  {node_result.status:>8s}  {node_result.node.unique_id:50s}  "

--- a/src/incremental_batches/augmented_incremental/redshift/setup_rs.py
+++ b/src/incremental_batches/augmented_incremental/redshift/setup_rs.py
@@ -6,14 +6,15 @@
 #   "psycopg2-binary",
 # ]
 # ///
-# Per-run Redshift setup. Dispatches DDL/CTAS to Redshift; no Spark compute
-# beyond the JDBC client. Steps:
-#   1. Bootstrap the staging schema tpcdi_staging_sf{sf} if missing (imports
-#      rs_staging_bootstrap, seeds Delta -> parquet -> COPY). Idempotent.
+# Per-run Redshift setup.
+# Dispatches DDL/CTAS to Redshift; no Spark compute beyond the JDBC client.
+# Steps:
+#   1. Bootstrap the staging schema tpcdi_staging_sf{sf} if missing
+#      (imports rs_staging_bootstrap, seeds Delta -> parquet -> COPY). Idempotent.
 #   2. CREATE the per-run schema {database}.{wh_db}_{sf}.
 #   3. CTAS the 22 staging tables into it (Redshift has no zero-copy clone).
-#   4. Pre-create the 6 streaming bronze tables empty (dbt fills them per
-#      batch via the rs_bronze_copy_prehook macro).
+#   4. Pre-create the 6 streaming bronze tables empty
+#      (dbt fills them per batch via the rs_bronze_copy_prehook macro).
 #   5. Emit batch_date_ls for the parent's for_each loop.
 #
 # Auth: connection creds from the `tpcdi_redshift` secret scope (see _rs_conn).
@@ -84,12 +85,12 @@ iam_role     = rs_iam_role(secret_scope=secret_scope)
 
 # COMMAND ----------
 
-# Bootstrap the staging schema if missing. Idempotent (no-op when all 22
-# tables are present with matching row counts).
+# Bootstrap the staging schema if missing.
+# Idempotent — a no-op when all 22 tables are present with matching row counts.
 #
-# Each cell opens its own connection and closes it — a phase can run >1hr at
-# SF=20k and idle Redshift Serverless SSL sockets get dropped; a long-lived
-# conn would go stale between cells.
+# Each cell opens and closes its own connection.
+# A phase can run over an hour at SF=20k, and idle Redshift Serverless SSL
+# sockets get dropped, so a long-lived conn would go stale between cells.
 _conn = rs_connect(database=database, secret_scope=secret_scope,
                    query_group={"wh_db": wh_db, "scale_factor": scale_factor,
                                 "task": "setup_rs", "phase": "bootstrap"})
@@ -116,9 +117,10 @@ finally:
 
 # COMMAND ----------
 
-# Ensure the per-run schema exists. force_reset=YES drops it first (re-CTAS
-# everything); default keeps existing tables so the CTAS step below can skip
-# any already present with matching row counts.
+# Ensure the per-run schema exists.
+# force_reset=YES drops it first (re-CTAS everything).
+# Default keeps existing tables so the CTAS step below can skip any already
+# present with matching row counts.
 _conn = rs_connect(database=database, secret_scope=secret_scope,
                    query_group={"wh_db": wh_db, "scale_factor": scale_factor,
                                 "task": "setup_rs", "phase": "schema_init"})
@@ -135,9 +137,10 @@ finally:
 # COMMAND ----------
 
 # Per-table distribution + sort layout, declared at CREATE time (Redshift
-# DISTKEY/SORTKEY/DISTSTYLE are immutable). Small reference/dim tables use
-# DISTSTYLE ALL (replicated, local joins); large facts use DISTKEY on the
-# main join column. See PORT_NOTES.md for the strategy rationale.
+# DISTKEY/SORTKEY/DISTSTYLE are immutable).
+# Small reference/dim tables use DISTSTYLE ALL (replicated, local joins);
+# large facts use DISTKEY on the main join column.
+# See PORT_NOTES.md for the strategy rationale.
 #   value = (distribution_spec, sortkey_cols)
 #   distribution_spec: "ALL" | "EVEN" | "KEY(col)"
 TABLE_LAYOUTS = {
@@ -275,17 +278,19 @@ print(f"[parallel] CTAS done in {_time.time() - t_clone:.1f}s")
 
 # COMMAND ----------
 
-# Pre-create the 6 streaming bronze tables empty. They have no staging
-# source — dbt fills them each batch via rs_bronze_copy_prehook (CREATE TEMP
-# TABLE LIKE this + COPY from S3 + INSERT). The pre-hook's `LIKE this`
-# requires the table to already exist, hence these DDLs. Types mirror the
-# Databricks bronze layer in setup_dbt.py (STRING->VARCHAR, TINYINT->SMALLINT,
-# DOUBLE->DOUBLE PRECISION); VARCHAR widths are upper bounds only.
+# Pre-create the 6 streaming bronze tables empty.
+# They have no staging source — dbt fills them each batch via
+# rs_bronze_copy_prehook (CREATE TEMP TABLE LIKE this + COPY from S3 + INSERT).
+# The pre-hook's `LIKE this` requires the table to already exist, hence these DDLs.
+# Types mirror the Databricks bronze layer in setup_dbt.py
+# (STRING->VARCHAR, TINYINT->SMALLINT, DOUBLE->DOUBLE PRECISION);
+# VARCHAR widths are upper bounds only.
 #
-# account_updates_from_customer is deliberately NOT pre-created: its model
-# has no pre_hook (it's a pure SELECT off bronzecustomer+dimaccount), so dbt
-# CTAS's it on first run. Pre-creating it would make dbt rewrite+reorder the
-# columns, breaking dimaccount's by-position UNION against bronzeaccount.
+# account_updates_from_customer is deliberately NOT pre-created.
+# Its model has no pre_hook (it's a pure SELECT off bronzecustomer+dimaccount),
+# so dbt CTAS's it on first run.
+# Pre-creating it would make dbt rewrite+reorder the columns, breaking
+# dimaccount's by-position UNION against bronzeaccount.
 BRONZE_DDLS = {
     "bronzecustomer": """
         cdc_flag        VARCHAR(1),

--- a/src/incremental_batches/augmented_incremental/redshift/setup_rs.py
+++ b/src/incremental_batches/augmented_incremental/redshift/setup_rs.py
@@ -6,30 +6,17 @@
 #   "psycopg2-binary",
 # ]
 # ///
-# Per-run Redshift setup. Dispatches DDL/CTAS to Redshift from a Databricks
-# task. No Spark compute needed beyond the JDBC client.
+# Per-run Redshift setup. Dispatches DDL/CTAS to Redshift; no Spark compute
+# beyond the JDBC client. Steps:
+#   1. Bootstrap the staging schema tpcdi_staging_sf{sf} if missing (imports
+#      rs_staging_bootstrap, seeds Delta -> parquet -> COPY). Idempotent.
+#   2. CREATE the per-run schema {database}.{wh_db}_{sf}.
+#   3. CTAS the 22 staging tables into it (Redshift has no zero-copy clone).
+#   4. Pre-create the 6 streaming bronze tables empty (dbt fills them per
+#      batch via the rs_bronze_copy_prehook macro).
+#   5. Emit batch_date_ls for the parent's for_each loop.
 #
-# Sequence:
-#   1. DROP+CREATE the per-run Redshift schema {database}.{wh_db}_{sf}
-#   2. CTAS 22 historical/reference tables from {database}.tpcdi_staging_sf{sf}
-#      (zero-copy clone isn't available in Redshift; CTAS is the lightweight
-#      alternative, ~1-3 min at SF=20k for the 22 tables together).
-#      Includes bronzedailymarket — its 1-year history is needed for the
-#      FactMarketHistory MIN/MAX lookback.
-#   3. Pre-create 7 EMPTY tables (6 streaming bronze + account_updates_from_customer)
-#      with DISTKEY/SORTKEY but no data — dbt populates per-batch via the
-#      rs_bronze_copy_prehook macro (CREATE TEMP TABLE LIKE this + COPY +
-#      INSERT INTO this). Mirrors the empty-CREATE-TABLE pattern in setup_dbt.py
-#      lines 132-251 for the equivalent Databricks bronze layer.
-#   4. Emit batch_date_ls task value for the parent's for_each loop
-#
-# Self-bootstrapping: if {database}.tpcdi_staging_sf{sf} doesn't exist yet
-# for this scale factor, this notebook imports `rs_staging_bootstrap` and
-# seeds it inline (Delta → parquet → Redshift COPY). Idempotent — no-op
-# when all 22 staging tables are already present. No separate workflow
-# task; mirrors setup_bq.py's bootstrap pattern.
-#
-# Auth: reads connection creds from `tpcdi_redshift` secret scope (see _rs_conn).
+# Auth: connection creds from the `tpcdi_redshift` secret scope (see _rs_conn).
 
 # COMMAND ----------
 
@@ -97,15 +84,12 @@ iam_role     = rs_iam_role(secret_scope=secret_scope)
 
 # COMMAND ----------
 
-# 0. Self-bootstrap the staging schema if needed. Mirrors setup_bq.py /
-#    setup_sf.py pattern. Idempotent — no-op when all 22 staging tables
-#    already present with row counts matching their COMMENT markers.
+# Bootstrap the staging schema if missing. Idempotent (no-op when all 22
+# tables are present with matching row counts).
 #
-# CONNECTION DISCIPLINE: every cell opens its own short-lived conn at the
-# top and closes it at the bottom. No long-lived conn carries state across
-# cells. Reason: at SF=20k a phase can take >1hr, and Redshift Serverless
-# SSL sockets idle-close (see today's post-mortem in commit 7129e9e). TCP
-# keepalives in rs_connect provide belt-and-suspenders.
+# Each cell opens its own connection and closes it — a phase can run >1hr at
+# SF=20k and idle Redshift Serverless SSL sockets get dropped; a long-lived
+# conn would go stale between cells.
 _conn = rs_connect(database=database, secret_scope=secret_scope,
                    query_group={"wh_db": wh_db, "scale_factor": scale_factor,
                                 "task": "setup_rs", "phase": "bootstrap"})
@@ -132,11 +116,9 @@ finally:
 
 # COMMAND ----------
 
-# 1. Ensure the per-run schema exists. Two modes:
-#    - force_reset=YES → DROP CASCADE + CREATE (slow at SF=20k: throws away
-#      every CTAS'd table; the next cell re-does all 22)
-#    - default (idempotent) → CREATE IF NOT EXISTS; existing tables stay
-#      and cell 8 skips per-table CTAS where staging row counts match.
+# Ensure the per-run schema exists. force_reset=YES drops it first (re-CTAS
+# everything); default keeps existing tables so the CTAS step below can skip
+# any already present with matching row counts.
 _conn = rs_connect(database=database, secret_scope=secret_scope,
                    query_group={"wh_db": wh_db, "scale_factor": scale_factor,
                                 "task": "setup_rs", "phase": "schema_init"})
@@ -152,22 +134,12 @@ finally:
 
 # COMMAND ----------
 
-# 2. CTAS 22 staging tables into the per-run schema with explicit
-#    DISTKEY/SORTKEY/DISTSTYLE declarations.
-#
-# Per Redshift semantics: DISTKEY/SORTKEY/DISTSTYLE are immutable once a table
-# exists — must be declared at CREATE time. Setup owns the layout; dbt models
-# declare nothing about distribution.
-#
-# Layout strategy decisions are documented in PORT_NOTES.md "DISTKEY / SORTKEY
-# strategy" section. Small reference tables (under ~5M rows) get DISTSTYLE ALL
-# so every node has a copy and joins stay local. Large facts use DISTKEY on
-# the most-frequent join column.
-#
-# Format below: (table_name, distribution_spec, sortkey_cols)
-#   distribution_spec: "ALL" | f"KEY({col})" | "EVEN"
-#   sortkey_cols: tuple of column names for compound SORTKEY (Redshift's
-#                 default); empty tuple = no sort key
+# Per-table distribution + sort layout, declared at CREATE time (Redshift
+# DISTKEY/SORTKEY/DISTSTYLE are immutable). Small reference/dim tables use
+# DISTSTYLE ALL (replicated, local joins); large facts use DISTKEY on the
+# main join column. See PORT_NOTES.md for the strategy rationale.
+#   value = (distribution_spec, sortkey_cols)
+#   distribution_spec: "ALL" | "EVEN" | "KEY(col)"
 TABLE_LAYOUTS = {
     # Facts (large) — DISTKEY on join column, SORTKEY on date(s) for prune
     "factmarkethistory":          ("KEY(sk_securityid)", ("sk_dateid", "sk_securityid", "sk_companyid")),
@@ -206,8 +178,8 @@ TABLE_LAYOUTS = {
     "cashtransactionhistorical":  ("KEY(accountid)",     ("event_dt", "ct_dts")),
 }
 
-# Verify completeness against the canonical 22 STAGING_TABLES set used on
-# the SF / BQ sides. Update this list if the canonical set ever changes.
+# Canonical 22 staging tables (matches the SF/BQ sides). Guards TABLE_LAYOUTS
+# against drift.
 STAGING_TABLES_EXPECTED = {
     "bronzedailymarket", "factmarkethistory", "factwatches", "dimtrade",
     "factholdings", "factcashbalances", "cashtransactionhistorical",
@@ -224,17 +196,13 @@ if _missing_layouts:
 
 # COMMAND ----------
 
-# Run the 22 CTAS statements in parallel. Independent table writes — Redshift's
-# psql wire protocol supports concurrent statements (each cursor on its own
-# implicit transaction).
+# CTAS the 22 tables in parallel (independent writes, one connection each).
 import concurrent.futures as _cf
 import time as _time
 
 def _ctas_one(table_name: str) -> tuple[str, float, str]:
-    """CTAS one table. Idempotent: if target already exists with row count
-    matching the staging source, skip the CTAS entirely. Returns
-    (table_name, elapsed_s, status) where status ∈ {'ctas', 'skip'}.
-    """
+    """CTAS one table into the run schema. Idempotent: skips if the target
+    already holds the staging row count. Returns (name, elapsed_s, status)."""
     dist_spec, sortkey_cols = TABLE_LAYOUTS[table_name]
 
     # Build the layout clauses. `DISTKEY(col)` alone implies `DISTSTYLE KEY`.
@@ -251,8 +219,7 @@ def _ctas_one(table_name: str) -> tuple[str, float, str]:
     sort_sql = f"SORTKEY({', '.join(sortkey_cols)})" if sortkey_cols else ""
 
     t0 = _time.time()
-    # Each thread needs its own connection — psycopg2 connections aren't safe
-    # for concurrent use across threads.
+    # Own connection per thread — psycopg2 connections aren't thread-safe.
     local_conn = rs_connect(
         database=database, secret_scope=secret_scope,
         query_group={"task": "setup_rs", "phase": "ctas", "table": table_name,
@@ -260,9 +227,8 @@ def _ctas_one(table_name: str) -> tuple[str, float, str]:
     )
     try:
         with local_conn.cursor() as cur:
-            # Idempotency check: does the target already exist with the
-            # right row count? If yes, skip CTAS. Saves multi-hour re-runs
-            # at SF=20k when a prior attempt got partway through.
+            # Skip if the target already has the staging row count (lets a
+            # partial prior run resume without re-CTAS'ing finished tables).
             cur.execute("""
                 SELECT EXISTS (
                   SELECT 1 FROM information_schema.tables
@@ -309,24 +275,17 @@ print(f"[parallel] CTAS done in {_time.time() - t_clone:.1f}s")
 
 # COMMAND ----------
 
-# 3. Pre-create 7 EMPTY bronze + account_updates_from_customer tables with
-#    DISTKEY/SORTKEY. These tables have NO staging source — dbt populates
-#    them per batch via the rs_bronze_copy_prehook macro:
-#      (a) CREATE TEMP TABLE foo_stg (LIKE foo)  -- needs foo to exist!
-#      (b) COPY foo_stg FROM 's3://...' FORMAT AS CSV ...
-#      (c) INSERT INTO foo SELECT * FROM foo_stg  -- dbt's append strategy
+# Pre-create the 6 streaming bronze tables empty. They have no staging
+# source — dbt fills them each batch via rs_bronze_copy_prehook (CREATE TEMP
+# TABLE LIKE this + COPY from S3 + INSERT). The pre-hook's `LIKE this`
+# requires the table to already exist, hence these DDLs. Types mirror the
+# Databricks bronze layer in setup_dbt.py (STRING->VARCHAR, TINYINT->SMALLINT,
+# DOUBLE->DOUBLE PRECISION); VARCHAR widths are upper bounds only.
 #
-#    Column schemas mirror setup_dbt.py lines 132-251 (the Databricks
-#    equivalent of these tables). Redshift type swaps: STRING→VARCHAR(N),
-#    TINYINT→SMALLINT, DOUBLE→DOUBLE PRECISION. The VARCHAR widths are
-#    upper bounds for the CSV columns; over-allocating costs no on-disk
-#    bytes in Redshift (length is stored, not padded).
-#
-#    `account_updates_from_customer` mirrors bronzeaccount's schema — it's
-#    a dbt-managed staging table derived from bronzecustomer 'U' events
-#    for dimaccount to UNION with the day's bronzeaccount file drops.
-#    Its rs_bronze model has no pre_hook (no S3 source); it INSERTs from
-#    a SELECT, so the pre-creation gives the model a valid {{ this }}.
+# account_updates_from_customer is deliberately NOT pre-created: its model
+# has no pre_hook (it's a pure SELECT off bronzecustomer+dimaccount), so dbt
+# CTAS's it on first run. Pre-creating it would make dbt rewrite+reorder the
+# columns, breaking dimaccount's by-position UNION against bronzeaccount.
 BRONZE_DDLS = {
     "bronzecustomer": """
         cdc_flag        VARCHAR(1),
@@ -375,18 +334,6 @@ BRONZE_DDLS = {
         status      VARCHAR(10),
         update_dt   DATE
     """,
-    # NOTE: account_updates_from_customer is intentionally NOT pre-created.
-    # Its rs_bronze model has no pre_hook (no S3 source — body is a pure
-    # SELECT joining bronzecustomer + dimaccount). With incremental_strategy
-    # = 'append' on a non-existent target, dbt does CREATE TABLE AS SELECT
-    # the first time, inferring column types from the SELECT (a.accountdesc
-    # widens to VARCHAR(65535) from dimaccount's source).
-    #
-    # If we pre-create it like bronzeaccount, dbt detects the schema differs
-    # from its SELECT and rewrites the table — but the rewrite reorders
-    # columns (varchars to the end), which breaks dimaccount's
-    # `select * ... union all select * ...` by-position type matching
-    # against bronzeaccount.
     "bronzecashtransaction": """
         cdc_flag VARCHAR(1),
         cdc_dsn  BIGINT,
@@ -435,8 +382,8 @@ BRONZE_DDLS = {
     """,
 }
 
-# Layouts (DISTKEY + SORTKEY) for the 7 empty bronze tables. Mirrors the
-# CLUSTER BY column in setup_dbt.py: dist on natural ID, sort on batch-date.
+# DISTKEY on natural ID, SORTKEY on batch-date (mirrors the setup_dbt.py
+# CLUSTER BY choices).
 BRONZE_LAYOUTS = {
     "bronzecustomer":                ("KEY(customerid)", ("update_dt",)),
     "bronzeaccount":                 ("KEY(accountid)",  ("update_dt",)),
@@ -463,9 +410,8 @@ try:
         for tbl, cols_sql in BRONZE_DDLS.items():
             dist_spec, sortkey_cols = BRONZE_LAYOUTS[tbl]
             sort_sql = f"SORTKEY({', '.join(sortkey_cols)})" if sortkey_cols else ""
-            # IF NOT EXISTS: idempotent. dbt may have already populated bronze
-            # tables on a prior partial run; preserve their data on re-run.
-            # If schema needs to change, use force_reset=YES at the top.
+            # IF NOT EXISTS preserves any dbt-loaded rows on re-run; use
+            # force_reset=YES to change the schema.
             ddl = f'''
                 CREATE TABLE IF NOT EXISTS "{target_schema}"."{tbl}" (
                   {cols_sql.strip().rstrip(",")}
@@ -480,8 +426,8 @@ finally:
 
 # COMMAND ----------
 
-# 4. Emit batch_date_ls — match setup_dbt.py / setup_sf.py / setup_bq.py exactly:
-#    AUG_FILES_DATE_START is hardcoded to 2016-07-06.
+# Emit the batch-date list for the parent's for_each loop. Window starts
+# 2016-07-06 (AUG_FILES_DATE_START), matching the other setup notebooks.
 import datetime as dt
 incr_start = dt.date(2016, 7, 6)
 batches = [(incr_start + dt.timedelta(days=i)).isoformat()

--- a/src/incremental_batches/augmented_incremental/redshift/simulate_filedrops_rs.py
+++ b/src/incremental_batches/augmented_incremental/redshift/simulate_filedrops_rs.py
@@ -5,13 +5,11 @@
 # ///
 # Per-batch task: copies the day's pre-staged .txt files from `_staging/sf=N/`
 # to the per-(wh_db, sf, batch_date) directory under the UC external volume.
-# Redshift reads the same bytes via the COPY statement issued by
-# load_bronze_rs.py.
+# Redshift reads the same bytes via the COPY in each dbt bronze pre_hook.
 #
-# Adapter of simulate_filedrops_bq.py. The Redshift workgroup is in us-west-2
-# and the UC external volume's S3 backing bucket is also us-west-2 —
-# zero cross-region transfer. Mirrors the BQ pattern except the per-batch
-# dir naming follows lowercased Redshift identifier convention.
+# Adapter of simulate_filedrops_bq.py.
+# Keep the workgroup and the S3-backed volume in the same region to avoid
+# cross-region transfer. Per-batch dir names are lowercased (Redshift convention).
 
 import os
 import concurrent.futures
@@ -48,7 +46,7 @@ DATASETS = [
 
 # COMMAND ----------
 
-# Clear prior day's files so load_bronze_rs's COPY doesn't accidentally pick
+# Clear the prior day's files so the bronze pre_hook COPY doesn't pick
 # up stale data.
 if os.path.exists(batches_dir):
     dbutils.fs.rm(batches_dir, recurse=True)


### PR DESCRIPTION
First file-set of the codebase concise pass. **Comments only, zero logic change.**

Applies the agreed bar — remove bug-narrative / color-commentary; keep the 'why' that prevents future breakage — to the 3 heaviest Redshift files:
- `setup_rs.py` (494 -> 440 lines)
- `rs_staging_bootstrap.py` (406 -> 349)
- `_rs_conn.py` (keepalive comment trimmed)

**Removed:** commit-hash refs, post-mortems, 'we hit X at SF=20k' narratives, stale cell/line-number pointers.
**Kept:** DISTKEY/SORTKEY immutability, psycopg2 thread-safety, COPY exact-type-match, marker cleanup, fresh-conn rationale, the account_updates_from_customer non-precreate reason.

Posting this as a standalone PR so the comment bar can be reviewed before rolling the same pass across the rest of the 24k-line codebase.

This pull request and its description were written by Isaac.