### PR TITLE
Concise pass: genericize BigQuery project id across the BQ port

### DIFF
--- a/src/incremental_batches/augmented_incremental/bigquery/_bq_conn.py
+++ b/src/incremental_batches/augmented_incremental/bigquery/_bq_conn.py
@@ -7,11 +7,11 @@
 #   sa_json  — full service-account key JSON (single secret)
 #
 # The SA needs BigQuery Data Editor + BigQuery Job User on the target
-# project (default: `databricks-sandbox-perfeng`).
+# project (default: `<your-bq-project>`).
 #
 # Usage from a calling notebook:
 #   %run ./_bq_conn
-#   client = bq_connect(project="databricks-sandbox-perfeng",
+#   client = bq_connect(project="<your-bq-project>",
 #                       location="us-central1",
 #                       query_label={"task": "setup_bq"})
 #   client.query("SELECT 1").result()

--- a/src/incremental_batches/augmented_incremental/bigquery/bq_metrics.py
+++ b/src/incremental_batches/augmented_incremental/bigquery/bq_metrics.py
@@ -42,7 +42,7 @@ import argparse
 import subprocess
 import sys
 
-PROJECT = "databricks-sandbox-perfeng"
+PROJECT = "REPLACE-ME-bq-project"
 REGION = "region-us-central1"
 DEFAULT_WH_DB = "shannon_aug_bq_dbt"
 DEFAULT_SF = "10"

--- a/src/incremental_batches/augmented_incremental/bigquery/run_dbt.py
+++ b/src/incremental_batches/augmented_incremental/bigquery/run_dbt.py
@@ -29,7 +29,7 @@ import os, subprocess, sys, json, tempfile
 
 # COMMAND ----------
 
-dbutils.widgets.text("catalog",        "databricks-sandbox-perfeng",
+dbutils.widgets.text("catalog",        "REPLACE-ME-bq-project",
                      "Treated as BQ project — same meaning as `catalog` everywhere else")
 dbutils.widgets.text("wh_db",          "")
 dbutils.widgets.dropdown("scale_factor", "10", ["10","100","1000","5000","10000","20000"])

--- a/src/incremental_batches/augmented_incremental/bigquery/setup_bq.py
+++ b/src/incremental_batches/augmented_incremental/bigquery/setup_bq.py
@@ -26,7 +26,7 @@
 
 # COMMAND ----------
 
-dbutils.widgets.text("catalog",        "databricks-sandbox-perfeng", "BigQuery project (treated as `catalog`)")
+dbutils.widgets.text("catalog",        "REPLACE-ME-bq-project", "BigQuery project (treated as `catalog`)")
 dbutils.widgets.text("wh_db",          "", "wh_db prefix; final dataset = {wh_db}_{scale_factor}")
 dbutils.widgets.dropdown("scale_factor","10", ["10","100","1000","5000","10000","20000"])
 dbutils.widgets.text("tpcdi_directory","/Volumes/main/tpcdi_raw_data/tpcdi_volume/",

--- a/src/incremental_batches/augmented_incremental/bigquery/simulate_filedrops_bq.py
+++ b/src/incremental_batches/augmented_incremental/bigquery/simulate_filedrops_bq.py
@@ -21,7 +21,7 @@ import requests
 
 dbutils.widgets.dropdown("scale_factor","10", ["10","100","1000","5000","10000","20000"])
 dbutils.widgets.text("tpcdi_directory", "/Volumes/main/tpcdi_raw_data/tpcdi_volume/")
-dbutils.widgets.text("catalog",         "databricks-sandbox-perfeng",
+dbutils.widgets.text("catalog",         "REPLACE-ME-bq-project",
                      "Treated as BQ project — same meaning as `catalog` everywhere else")
 dbutils.widgets.text("batch_date",      "")
 dbutils.widgets.text("wh_db",           "")

--- a/src/incremental_batches/augmented_incremental/bigquery/teardown_bq.py
+++ b/src/incremental_batches/augmented_incremental/bigquery/teardown_bq.py
@@ -24,7 +24,7 @@
 
 # COMMAND ----------
 
-dbutils.widgets.text("catalog",          "databricks-sandbox-perfeng", "BigQuery project")
+dbutils.widgets.text("catalog",          "REPLACE-ME-bq-project", "BigQuery project")
 dbutils.widgets.text("wh_db",            "",                            "wh_db prefix")
 dbutils.widgets.dropdown("scale_factor", "10",
                          ["10", "100", "1000", "5000", "10000", "20000"])

--- a/src/incremental_batches/augmented_incremental/dbt/profiles.yml.template
+++ b/src/incremental_batches/augmented_incremental/dbt/profiles.yml.template
@@ -34,7 +34,7 @@ dbt_augmented_incremental:
       type: bigquery
       method: service-account
       keyfile: /tmp/bq_sa/sa.json                        # path to a service-account JSON key
-      project: databricks-sandbox-perfeng                # BQ project
+      project: <your-bq-project>                # BQ project
       dataset: dbt_augmented_incremental                 # overridden per-model via generate_schema_name macro
       location: us-central1                              # must match the GCS bucket region
       threads: 8

--- a/src/tools/workflow_builders/augmented_bigquery.py
+++ b/src/tools/workflow_builders/augmented_bigquery.py
@@ -10,8 +10,7 @@ REPLACEd per batch.
 Pre-requisites (one-time, manual, out-of-band):
 - A GCS bucket (e.g. `gs://<your-bucket>/tpcdi/`) in your region
 - UC external volume `main.tpcdi_raw_data.tpcdi_volume` backed by that bucket
-- BQ project `databricks-sandbox-perfeng` (or override via the `catalog`
-  job parameter)
+- A BigQuery project (supplied via the `catalog` job parameter)
 - Databricks secret scope `tpcdi_bigquery` with key `sa_json` containing a
   service-account key JSON with BigQuery Data Editor + Job User on the
   target project


### PR DESCRIPTION
workflow_builders/ and the BigQuery port have no war-story comments (already lean). The only publication issue was the hardcoded BQ project id `databricks-sandbox-perfeng`, now genericized: widget `catalog` defaults -> `REPLACE-ME-bq-project`, docstrings/template -> `<your-bq-project>`. No logic change.

This pull request and its description were written by Isaac.