### PR TITLE
Concise+readability pass: tpcdi_gen core generator comments

### DIFF
--- a/src/tools/tpcdi_gen/customer.py
+++ b/src/tools/tpcdi_gen/customer.py
@@ -644,7 +644,9 @@ def generate_customermgmt(spark: SparkSession, cfg, dicts: dict, dbutils, views_
         .drop("_rn"))
     all_df = _acct_targets.unionByName(_acct_others)
 
-    # Global one-INACT-per-customer and one-CLOSEACCT-per-account dedups are no longer needed: inact_schedule and close_schedule pre-pick unique C_IDs/CA_IDs across all updates by construction (scan-bijection with set exclusion). No duplicates can exist.
+    # No global INACT/CLOSEACCT dedup needed: inact_schedule and
+    # close_schedule pick unique C_IDs/CA_IDs across all updates by
+    # construction (scan-bijection with set exclusion), so no duplicates exist.
 
     # === Filter out ADDACCTs on the same day as their customer's INACT ===
     # An ADDACCT and INACT for the same customer on the same day would create a same-day conflict when we generate the synthetic CLOSEACCT. Remove the ADDACCT — no point creating an account for a customer being deactivated.
@@ -662,7 +664,14 @@ def generate_customermgmt(spark: SparkSession, cfg, dicts: dict, dbutils, views_
 
     # No cascade CLOSEACCT for INACT'd customers — DIGen's CustomerAccountBlackBox generates Customer DELETE (INACT) and Account DELETE (CLOSEACCT) as independent streams; INACT does not imply that the customer's accounts are closed. Adding cascade closes produced ~+51% CA_CLOSEACCT drift vs DIGen and indirectly suppressed UPDACCTs (Rule 3: no UPDACCT after CLOSEACCT) causing -29.7% CA_UPDACCT drift.
 
-    # Cache all_df — it's used to derive 4 views + the XML write + incrementals. Classic: persist; serverless: Parquet staging. Target ~100MB per XML file — the Databricks native XML reader cannot split XML files, so one file = one ingest task. 128MB files push task runtime too high (7+ min at SF=5000); 100MB keeps ingest parallelism reasonable. maxRecordsPerFile on both parquet staging (for read-back partitioning) and final XML write ensures bounded sizes without an explicit repartition. 580 bytes/row avg at SF=5000, with ~1.35x variance across partitions (largest file observed 157MB vs 116MB avg). To keep MAX file <=128MB we need max_records * worst-case-bytes <= 128MB → 128K records with ~1000 B/row worst case, producing avg ~74MB and max ~120MB. Favors file-count over file-size to stay safely under the XML reader's single-task constraint.
+    # Cache all_df — it feeds 4 views + the XML write + incrementals
+    # (classic: persist; serverless: Parquet staging).
+    #
+    # Cap rows-per-file rather than repartition: the Databricks XML reader
+    # can't split a file, so one file = one ingest task, and file size drives
+    # per-task runtime. Sizing for <=128MB/file (worst-case ~1000 B/row at
+    # SF=5000) lands ~75MB avg / ~120MB max, keeping ingest parallel without
+    # any single task running long.
     _xml_records_per_file = 128 * 1024  # 131K rows → ~75MB avg / ~120MB max
     all_df, _all_df_cleanup = disk_cache(all_df, spark, "CustomerMgmt actions",
                                           volume_path=cfg.volume_path, dbutils=dbutils, cfg=cfg,
@@ -832,7 +841,12 @@ def generate_customermgmt(spark: SparkSession, cfg, dicts: dict, dbutils, views_
     ).text(tmp_path)
     log(f"[CustomerMgmt] XML body written to staging")
 
-    # Step 2: Concat header + body + footer per file using pure-Python I/O. Previously this shelled out to `bash -c "cat hdr src ftr > dst"`; at SF=20000 with ~800 files concat'd in parallel, UC Volume FUSE throws EAGAIN ("Resource temporarily unavailable") on both reads and the output redirect. shell-level retries can't recover a half-written redirect once cat has already failed. Mirror the retry pattern used in utils.py register_copies_from_staging: open dst once, write header bytes, copyfileobj the source in 4MB chunks with per-source retry on OSError, then write footer bytes.
+    # Step 2: concat header + body + footer per file using pure-Python I/O.
+    # Use copyfileobj in 4MB chunks with per-source retry on OSError (same
+    # pattern as utils.register_copies_from_staging).
+    # A shell `cat hdr src ftr > dst` can't be retried safely: UC Volume FUSE
+    # throws EAGAIN under the parallel load at high SF, and a half-written
+    # redirect isn't recoverable once cat has failed.
     xml_header_bytes = b'<?xml version="1.0" encoding="UTF-8"?>\n<TPCDI:Actions xmlns:TPCDI="http://www.tpc.org/tpc-di">\n'
     xml_footer_bytes = b'\n</TPCDI:Actions>\n'
     import shutil, time as _time

--- a/src/tools/tpcdi_gen/finwire.py
+++ b/src/tools/tpcdi_gen/finwire.py
@@ -371,7 +371,10 @@ def generate(spark: SparkSession, cfg, dicts: dict, dbutils, symbols_ready_event
             Window.orderBy("creation_quarter", "Symbol")) - 1).cast("long"))
         .select("Symbol", "creation_quarter", "deactivation_quarter", "_idx"))
 
-    # Stage _symbols to Parquet so Trade/WatchHistory/DailyMarket can read it independently of the remaining FINWIRE compute (CMP/FIN union + the 10-25 min text write). This detaches downstream start time from the overall FINWIRE wallclock — previously they waited on f_fw.result(), now they wait on symbols_ready_event set right below.
+    # Stage _symbols to Parquet so Trade/WatchHistory/DailyMarket can start as
+    # soon as symbols are ready, rather than waiting on the rest of the FINWIRE
+    # compute (CMP/FIN union + the 10-25 min text write).
+    # They gate on symbols_ready_event (set just below), not the full stage.
     symbols, _sym_cleanup = disk_cache(symbols, spark, "FINWIRE symbols",
                                         volume_path=cfg.volume_path, dbutils=dbutils, cfg=cfg)
     symbols.createOrReplaceTempView("_symbols")
@@ -497,7 +500,11 @@ def generate(spark: SparkSession, cfg, dicts: dict, dbutils, symbols_ready_event
     # =====================================================================
     # Write CMP / SEC / FIN as separate staging dirs (in parallel).
     # =====================================================================
-    # The bronze-layer FINWIRE ingest reads all FINWIRE_*.txt files as a single globbed input and distinguishes record type by the 3-char type code at byte position 16, so it's indifferent to which file contains which subset — we don't need to union CMP/SEC/FIN into one output stream. Splitting lets the 3 writes fan out across executors in parallel, and avoids a 244M-row union + columnar→row that previously dominated the FINWIRE stage.
+    # Write CMP/SEC/FIN as separate files rather than unioning them.
+    # The bronze ingest globs all FINWIRE_*.txt and keys record type off the
+    # 3-char code at byte 16, so it doesn't care which file holds which subset.
+    # Splitting fans the 3 writes across executors and avoids a 244M-row union
+    # + columnar->row that would otherwise dominate the FINWIRE stage.
     max_records = int(128 * 1024 * 1024 / 260)  # ~260 bytes per fixed-width line
 
     # FIN repartition happens earlier, right on cmp_quarters before the crossJoin — see the block there. Doing it here (just before .write) would shuffle after the in-memory 475M-row compute had already been forced onto the narrow spark.range default partitioning, which is what causes the 15GB/task spill. CMP/SEC are small enough to use default partitioning and write directly.

--- a/src/tools/tpcdi_gen/trade_split.py
+++ b/src/tools/tpcdi_gen/trade_split.py
@@ -1,8 +1,7 @@
-"""V6: decomposed Trade generation — base + 4 parallel leaves.
+"""Decomposed Trade generation — base + 4 parallel leaves.
 
-Splits the work that today lives inside ``trade._gen_historical_trades``
-across 5 workflow tasks so each Trade-family dataset has its own
-repair-run granularity and writes happen in parallel:
+Splits Trade-family generation across 5 workflow tasks so each dataset has
+its own repair-run granularity and the writes happen in parallel:
 
   materialize_base(spark, cfg, dbutils, dicts) -> writes
     ``_gen_trade_df`` Delta to ``{wh_db}_{sf}_stage`` with the *minimum*
@@ -33,16 +32,8 @@ trades = ~300 GB at SF=20k — expensive to materialize, cheap to
 re-derive in the CT leaf), ``_trade_val``, ``_broker_idx``,
 ``_qty_val``, intermediate offsets.
 
-Inter-leaf state (the original ``_hh_hist_batch{N}``,
-``_ct_hist_batch{N}``, ``_t_submit_hist_batch{N}`` temp views) is
-*not* shared — each leaf computes the equivalent filter directly from
-``base_df``. This eliminates the inter-leaf dependency that would
-otherwise serialize the writes back together.
-
-Trade.py is intentionally left untouched — this is an additive module
-the new task notebooks call instead. Once V6 lands and is validated
-trade.py was deleted in the V8 cleanup pass once this module was the
-sole code path for Trade-family generation.
+Inter-leaf state is *not* shared — each leaf computes its filters directly
+from ``base_df``, so the writes don't serialize back together.
 """
 from datetime import datetime, timedelta
 
@@ -317,11 +308,10 @@ def gen_trade(spark, cfg, dbutils, dicts, base_df):
 
 def _gen_trade_incremental(spark, cfg, dbutils, base_df, *, batch_id: int,
                             n_valid: int, n_brokers: int, num_sec: int):
-    """B2/B3 Trade.txt CDC writer. Mirrors trade._gen_incremental_trades.
+    """B2/B3 Trade.txt CDC writer.
 
-    Originally consumed ``_hh_hist_batch{N}`` and ``_t_submit_hist_batch{N}``
-    temp views produced by sibling write functions; here we filter
-    ``base_df`` directly so the leaf is independent.
+    Filters ``base_df`` directly (rather than depending on sibling writers'
+    temp views) so the leaf runs independently.
     """
     symbols_df = spark.table("_symbols")
     bs = seed_for(f"T_B{batch_id}", "base")
@@ -388,7 +378,7 @@ def _gen_trade_incremental(spark, cfg, dbutils, base_df, *, batch_id: int,
     t_dts_cncl = f"{batch_date_str} 00:00:02"
     t_dts_cmpt = f"{batch_date_str} 00:00:03"
 
-    # CMPT tids — derive from base_df (originally _hh_hist_batch{N}).
+    # CMPT tids — derive from base_df.
     cmpt_tids = (base_df
         .filter(~F.col("_is_canceled"))
         .filter((F.col("_complete_ts") >= F.lit(b_start).cast("long")) &
@@ -398,7 +388,7 @@ def _gen_trade_incremental(spark, cfg, dbutils, base_df, *, batch_id: int,
     upd_cmpt = _build_u_rows(cmpt_tids, F.lit("CMPT"), t_dts_cmpt,
                              dsn_offset=n_new, bs_offset=21)
 
-    # SBMT/CNCL tids — derive from base_df (originally _t_submit_hist_batch{N}).
+    # SBMT/CNCL tids — derive from base_df.
     submit_in_window = (base_df
         .filter(F.col("_is_limit") &
                 (F.col("_submit_ts") >= F.lit(b_start).cast("long")) &

--- a/src/tools/tpcdi_gen/watch_history.py
+++ b/src/tools/tpcdi_gen/watch_history.py
@@ -221,7 +221,14 @@ def _gen_historical(spark, cfg, dbutils):
     n_cncl = del_pu * total_updates
     wh_total_hist = wh_rpu * total_updates
 
-    # Precompute generation sizes (Python side — only ~435 values). Also precompute bijective permutation parameters (b, c) per generation so each generation's ACTV records map to UNIQUE pair_ids via the LCG f(x) = (b*x + c) % new_cp_size (DIGen-style). This eliminates the hash collisions that previously caused ~5-25% WH_ACTIVE drift vs DIGen as scale grew — each record now gets a distinct pair instead of colliding with other records' hashes. `b` must be coprime with new_cp_size; we start from a large odd prime-ish candidate and step until gcd==1.
+    # Precompute generation sizes (Python side — only ~435 values), plus
+    # bijective permutation params (b, c) per generation.
+    # Each generation's ACTV records map to UNIQUE pair_ids via the LCG
+    # f(x) = (b*x + c) % new_cp_size (DIGen-style), so every record gets a
+    # distinct pair instead of colliding — a plain hash collides and drifts
+    # WH_ACTIVE ~5-25% vs DIGen as scale grows.
+    # `b` must be coprime with new_cp_size; start from a large odd candidate
+    # and step until gcd == 1.
     import math as _math
     import random as _rand
     _bc_rng = _rand.Random(seed_for("WH", "bcperm"))
@@ -407,7 +414,11 @@ def _gen_historical(spark, cfg, dbutils):
         .drop("_dd_rn"))
 
     # === Step 6: ACTV + CNCL generation using deterministic hash-based selection ===
-    # Previously used .sample(fraction).limit(target) which is stochastic per-partition and produces slightly different row counts on each re-evaluation (groupBy.count() vs. write_file). That divergence over-counts WH_RECORDS in the audit file by a few hundred rows vs. the actual file, breaking the automated_audit check "FactWatches active watches" (Row count + Inactive watches == cumulative WH_RECORDS). Replacing with a deterministic hash filter: pick rows where hash(c_id|symbol) mod M < cutoff. Count and write see identical rows.
+    # Deterministic selection: keep rows where hash(c_id|symbol) mod M < cutoff.
+    # The count and the write then see identical rows.
+    # (`.sample().limit()` is stochastic per-partition, so count vs. write
+    # diverge by a few hundred rows and break the "FactWatches active watches"
+    # audit check.)
     actv_df = deduped_df.withColumn("w_action", F.lit("ACTV"))
     n_actv = cfg.wh_actv_count
     target_total = cfg.wh_total


### PR DESCRIPTION
Comments only, no logic change. Trimmed version-narrative + dense wall-of-text comments in the core generator (customer, trade_split, watch_history, finwire) to the essential 'why', reflowed one-sentence-per-line. All DIGen-parity 'why' comments kept (they prevent re-introducing drift bugs). All files parse.

This pull request and its description were written by Isaac.