### PR TITLE
Concise pass: drop internal version tags in data_gen_tasks

### DIFF
--- a/src/tools/data_gen_tasks/_copy_helper.py
+++ b/src/tools/data_gen_tasks/_copy_helper.py
@@ -1,9 +1,9 @@
 """Shared helper for the per-dataset copy_* notebooks.
 
-perf/v7 — Parallel cross-directory ``mv`` to flat Batch* layout. Each
+Parallel cross-directory ``mv`` into the flat Batch* layout. Each
 ``copy_*`` task iterates Batch1/2/3 looking for ``{batch_path}/{base}``
 staging directories (Spark's output) and calls
-``register_copies_from_staging`` which mv's part files concurrently
+``register_copies_from_staging``, which mv's part files concurrently
 (ThreadPoolExecutor, 32 workers, EAGAIN-retry) into
 ``{batch_path}/{base}_K{ext}``. The (now empty) staging dir is
 removed at the end of a successful pass so retries cleanly skip.

--- a/src/tools/data_gen_tasks/gen_cashtransaction.py
+++ b/src/tools/data_gen_tasks/gen_cashtransaction.py
@@ -1,6 +1,6 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # data_gen task: gen_cashtransaction (V6 leaf)
+# MAGIC # data_gen task: gen_cashtransaction
 # MAGIC
 # MAGIC Reads ``_gen_trade_df`` Delta (produced by ``gen_trade_base``) and
 # MAGIC writes ``CashTransaction.txt`` for B1 (+ B2/B3 incrementals in

--- a/src/tools/data_gen_tasks/gen_holdinghistory.py
+++ b/src/tools/data_gen_tasks/gen_holdinghistory.py
@@ -1,6 +1,6 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # data_gen task: gen_holdinghistory (V6 leaf)
+# MAGIC # data_gen task: gen_holdinghistory
 # MAGIC
 # MAGIC Reads ``_gen_trade_df`` Delta (produced by ``gen_trade_base``) and
 # MAGIC writes ``HoldingHistory.txt`` for B1 (+ B2/B3 incrementals in

--- a/src/tools/data_gen_tasks/gen_trade.py
+++ b/src/tools/data_gen_tasks/gen_trade.py
@@ -1,6 +1,6 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # data_gen task: gen_trade (V6 leaf)
+# MAGIC # data_gen task: gen_trade
 # MAGIC
 # MAGIC Reads ``_gen_trade_df`` Delta (produced by ``gen_trade_base``) and
 # MAGIC writes ``Trade.txt`` for B1 (+ B2/B3 incrementals in standard

--- a/src/tools/data_gen_tasks/gen_trade_base.py
+++ b/src/tools/data_gen_tasks/gen_trade_base.py
@@ -1,6 +1,6 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # data_gen task: gen_trade_base (V6)
+# MAGIC # data_gen task: gen_trade_base
 # MAGIC
 # MAGIC Materializes ``_gen_trade_df`` Delta in
 # MAGIC ``{catalog}.{wh_db}_{sf}_stage`` with the *minimum* cross-task

--- a/src/tools/data_gen_tasks/gen_tradehistory.py
+++ b/src/tools/data_gen_tasks/gen_tradehistory.py
@@ -1,6 +1,6 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # data_gen task: gen_tradehistory (V6 leaf)
+# MAGIC # data_gen task: gen_tradehistory
 # MAGIC
 # MAGIC Reads ``_gen_trade_df`` Delta (produced by ``gen_trade_base``) and
 # MAGIC writes ``TradeHistory.txt`` (B1 only — TH is historical-only).


### PR DESCRIPTION
data_gen_tasks/ has no war-story comments. Removed internal `(V6 leaf)` / `perf/v7` version tags that mean nothing to a public reader. No logic change.

This pull request and its description were written by Isaac.