### PR TITLE
Concise pass: genericize identifiers in the Snowflake port

### DIFF
--- a/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factcashbalances.py
+++ b/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factcashbalances.py
@@ -14,7 +14,7 @@ dbutils.widgets.dropdown("scale_factor", "10", ["10","100","1000","5000","10000"
 dbutils.widgets.text("batch_date",     "")
 dbutils.widgets.text("secret_scope",   "tpcdi_snowflake")
 dbutils.widgets.text("snowflake_warehouse", "BARROW_MED_GEN2")
-dbutils.widgets.text("snowflake_stage", "TPCDI_TEST.PUBLIC.SHANNON_TPCDI_STAGE")
+dbutils.widgets.text("snowflake_stage", "<db>.<schema>.<your_stage>")
 
 catalog       = dbutils.widgets.get("catalog")
 wh_db         = dbutils.widgets.get("wh_db")

--- a/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factholdings.py
+++ b/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factholdings.py
@@ -15,7 +15,7 @@ dbutils.widgets.dropdown("scale_factor", "10", ["10","100","1000","5000","10000"
 dbutils.widgets.text("batch_date",     "")
 dbutils.widgets.text("secret_scope",   "tpcdi_snowflake")
 dbutils.widgets.text("snowflake_warehouse", "BARROW_MED_GEN2")
-dbutils.widgets.text("snowflake_stage", "TPCDI_TEST.PUBLIC.SHANNON_TPCDI_STAGE")
+dbutils.widgets.text("snowflake_stage", "<db>.<schema>.<your_stage>")
 
 catalog       = dbutils.widgets.get("catalog")
 wh_db         = dbutils.widgets.get("wh_db")

--- a/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factmarkethistory.py
+++ b/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factmarkethistory.py
@@ -14,7 +14,7 @@ dbutils.widgets.dropdown("scale_factor", "10", ["10","100","1000","5000","10000"
 dbutils.widgets.text("batch_date",     "")
 dbutils.widgets.text("secret_scope",   "tpcdi_snowflake")
 dbutils.widgets.text("snowflake_warehouse", "BARROW_MED_GEN2")
-dbutils.widgets.text("snowflake_stage", "TPCDI_TEST.PUBLIC.SHANNON_TPCDI_STAGE")
+dbutils.widgets.text("snowflake_stage", "<db>.<schema>.<your_stage>")
 
 catalog       = dbutils.widgets.get("catalog")
 wh_db         = dbutils.widgets.get("wh_db")

--- a/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factwatches.py
+++ b/src/incremental_batches/augmented_incremental/snowflake/dynamic_tables/branch_factwatches.py
@@ -14,7 +14,7 @@ dbutils.widgets.dropdown("scale_factor", "10", ["10","100","1000","5000","10000"
 dbutils.widgets.text("batch_date",     "")
 dbutils.widgets.text("secret_scope",   "tpcdi_snowflake")
 dbutils.widgets.text("snowflake_warehouse", "BARROW_MED_GEN2")
-dbutils.widgets.text("snowflake_stage", "TPCDI_TEST.PUBLIC.SHANNON_TPCDI_STAGE")
+dbutils.widgets.text("snowflake_stage", "<db>.<schema>.<your_stage>")
 
 catalog       = dbutils.widgets.get("catalog")
 wh_db         = dbutils.widgets.get("wh_db")

--- a/src/incremental_batches/augmented_incremental/snowflake/sf_staging_bootstrap.py
+++ b/src/incremental_batches/augmented_incremental/snowflake/sf_staging_bootstrap.py
@@ -412,7 +412,7 @@ def materialize_bronze_into_schema(
     databricks_catalog_namespace: Optional[str] = None,
 ) -> None:
     """Per-run CTAS — copy each of the 7 federated bronze Iceberg tables into
-    `target_schema` (the per-benchmark schema, e.g. SHANNON_AUG_SF_DT_10).
+    `target_schema` (the per-benchmark schema, e.g. TPCDI_AUG_SF_DT_10).
 
     Targets keep the source name (no `_raw` suffix). Tables are created
     with `CHANGE_TRACKING = TRUE` so downstream DTs can incrementally


### PR DESCRIPTION
Snowflake port has no war-story comments. Genericized remaining personal identifiers: the `snowflake_stage` widget defaults in the 4 `branch_*` DT files and one docstring example schema. No logic change.

This pull request and its description were written by Isaac.