### PR TITLE
Genericize last personal identifier (test fixture wh_db)

### DIFF
--- a/tests/test_workflow_builders.py
+++ b/tests/test_workflow_builders.py
@@ -261,7 +261,7 @@ _AUG_COMMON = {
     "catalog": "main",
     "scale_factor": 20000,
     "tpcdi_directory": "/Volumes/main/tpcdi_raw_data/tpcdi_volume/",
-    "wh_db": "Shannon_Barrow_TPCDI_AugmentedIncremental_Cluster",
+    "wh_db": "TPCDI_AugmentedIncremental_Cluster",
     "repo_src_path": COMMON["repo_src_path"],
 }
 


### PR DESCRIPTION
Final identifier from the whole-repo sweep — a test fixture wh_db. No assertion depends on it; all 17 workflow-builder tests pass.

This pull request and its description were written by Isaac.