### PR TITLE
driver: ARM node types + linear cluster sizing (single-node ≤32 cores)

### DIFF
--- a/src/tools/generate_benchmark_workflow.py
+++ b/src/tools/generate_benchmark_workflow.py
@@ -9,6 +9,7 @@ import json
 from typing import Callable, Optional
 
 from _workflow_utils import submit_dag
+from workflow_builders import _workflow_common
 from workflow_builders import sdp_pipeline as _sdp_pipeline_builder
 from workflow_builders import sdp_workflow as _sdp_workflow_builder
 from workflow_builders import warehouse as _warehouse_builder
@@ -193,7 +194,8 @@ def generate_benchmark_workflow(
     default_dbr_version: Optional[str] = None,
     default_worker_type: Optional[str] = None,
     cust_mgmt_type: Optional[str] = None,
-    worker_cores_mult: Optional[float] = None,
+    worker_cores_mult: Optional[float] = None,  # deprecated: sizing now uses
+                                                # _workflow_common.plan_worker_count
     node_types: Optional[dict] = None,
 ) -> int:
     """Render the benchmark workflow template and submit it.
@@ -265,13 +267,14 @@ def generate_benchmark_workflow(
     # --- Compute selection ---
     if sku[0] == "CLUSTER" and serverless != "YES":
         if not all([worker_node_type, driver_node_type, dbr_version_id,
-                    worker_cores_mult, node_types]):
+                    node_types]):
             raise ValueError(
                 "Non-serverless CLUSTER workflow requires worker_node_type, "
-                "driver_node_type, dbr_version_id, worker_cores_mult, and "
-                "node_types")
-        worker_node_count = round(
-            scale_factor * worker_cores_mult / node_types[worker_node_type]["num_cores"])
+                "driver_node_type, dbr_version_id, and node_types")
+        # Linear sizing from measured tuning (144 worker cores at SF=10000);
+        # <=32 total cores => single node. See _workflow_common.plan_worker_count.
+        worker_node_count = _workflow_common.plan_worker_count(
+            scale_factor, node_types[worker_node_type]["num_cores"])
         if worker_node_count == 0:
             driver_node_type = worker_node_type
         dag_args["worker_node_type"] = worker_node_type
@@ -315,13 +318,14 @@ def generate_benchmark_workflow(
             f"creation will potentially fail. If it does, select 'NO' for the "
             f"Serverless widget.")
     elif sku[0] == "SDP":
-        if not all([worker_node_type, driver_node_type, worker_cores_mult,
-                    node_types]):
+        if not all([worker_node_type, driver_node_type, node_types]):
             raise ValueError(
                 "SDP workflow requires worker_node_type, driver_node_type, "
-                "worker_cores_mult, and node_types")
-        sdp_count = max(1, round(
-            scale_factor * worker_cores_mult / node_types[worker_node_type]["num_cores"]))
+                "and node_types")
+        # Same linear tuning as CLUSTER (144 worker cores at SF=10000), but SDP
+        # always needs >=1 worker (no true single-node), so floor the count.
+        sdp_count = max(1, _workflow_common.plan_worker_count(
+            scale_factor, node_types[worker_node_type]["num_cores"]))
         dag_args["sdp_worker_node_type"] = worker_node_type
         dag_args["sdp_driver_node_type"] = driver_node_type
         dag_args["sdp_worker_node_count"] = sdp_count

--- a/src/tools/setup_context.py
+++ b/src/tools/setup_context.py
@@ -161,17 +161,20 @@ class SetupContext:
     # ---------- Cloud-specific compute + catalog default ----------
 
     def _init_compute_and_catalog_defaults(self):
+        # ARM-based, local-NVMe node families per cloud (Graviton / Cobalt /
+        # Axion). ARM gives the best price/perf for the TPC-DI gen + benchmark
+        # compute; the -d/-lssd suffixes provide local disk for shuffle/spill.
         if self.cloud_provider == "AWS":
-            self.default_worker_type = "m7gd.2xlarge"
-            self.default_driver_type = "m7gd.xlarge"
-            self.cust_mgmt_type = "m7gd.16xlarge"
+            self.default_worker_type = "m8gd.2xlarge"
+            self.default_driver_type = "m8gd.xlarge"
+            self.cust_mgmt_type = "m8gd.16xlarge"
         elif self.cloud_provider == "GCP":
-            self.default_worker_type = "n2-standard-8"
-            self.default_driver_type = "n2-standard-4"
-            self.cust_mgmt_type = "n2-standard-64"
+            self.default_worker_type = "c4a-standard-8-lssd"
+            self.default_driver_type = "c4a-standard-4-lssd"
+            self.cust_mgmt_type = "c4a-standard-64-lssd"
             self.worker_cores_mult = self.worker_cores_mult * 1.5
         elif self.cloud_provider == "Azure":
-            self.default_worker_type = "Standard_D8ads_v5"
-            self.default_driver_type = "Standard_D4as_v5"
-            self.cust_mgmt_type = "Standard_D64ads_v5"
+            self.default_worker_type = "Standard_D8pds_v6"
+            self.default_driver_type = "Standard_D4pds_v6"
+            self.cust_mgmt_type = "Standard_D64pds_v6"
         self.default_catalog = "tpcdi"

--- a/src/tools/workflow_builders/_workflow_common.py
+++ b/src/tools/workflow_builders/_workflow_common.py
@@ -6,7 +6,27 @@ task and cluster shapes.
 """
 from __future__ import annotations
 
+import math
 from typing import Any
+
+
+def plan_worker_count(scale_factor: int, worker_cores: int) -> int:
+    """Worker count for a non-augmented (single-batch / incremental) run,
+    from measured tuning: worker cores scale linearly at 144 cores per
+    SF=10000. At <=32 total worker cores we return 0 (single node) — a big
+    single box loses enough per-core perf that a driver + 8-core workers is
+    cheaper, and below that a cluster isn't worth the overhead.
+
+        cores        = 144 * scale_factor / 10000
+        <= 32 cores  -> 0 (caller builds a single-node cluster)
+        >  32 cores  -> ceil(cores / worker_cores) workers
+
+    Mirrors models.cluster_plan in the benchmark app (non-augmented branch).
+    """
+    cores = 144 * scale_factor / 10000
+    if cores <= 32:
+        return 0
+    return math.ceil(cores / worker_cores)
 
 
 _DEFAULT_NOTIF = {


### PR DESCRIPTION
Cherry-pick of the driver-side compute changes (the rest of the benchmark-app work stays on `feature/databricks-app`).

## What changed
- **ARM node families** (`setup_context._init_compute_and_catalog_defaults`): per-cloud worker/driver/cust_mgmt now use ARM + local-NVMe instances — AWS `m8gd`, Azure `Standard_D*pds_v6`, GCP `c4a-*-lssd` — for better price/perf on the TPC-DI gen + benchmark compute.
- **Linear cluster sizing** (`_workflow_common.plan_worker_count`): non-augmented (single-batch / incremental) worker cores scale linearly at **144 cores per SF=10000**; **≤32 total cores → single node**, otherwise `ceil(cores / worker_cores)` workers. `generate_benchmark_workflow` CLUSTER + SDP branches use it instead of the old `worker_cores_mult=0.016` formula (SDP floors at 1 worker; `worker_cores_mult` kept as a deprecated no-op arg for call-compat).

## Resulting sizing (non-aug, 8-core workers)
| SF | Workers |
|----|---------|
| ≤~2200 | single node |
| 5000 | 9 |
| 10000 | 18 |
| 20000 | 36 |

Augmented variants remain serverless (no job cluster to size).

## Testing
- `tests/test_workflow_builders.py`: 17 passed.
- Sizing verified in parity with the benchmark app's `cluster_plan`.

This pull request and its description were written by Isaac.